### PR TITLE
#10 Add global keymap overlay parity across modes

### DIFF
--- a/internal/app/menu_model.go
+++ b/internal/app/menu_model.go
@@ -209,7 +209,7 @@ func (m MenuModel) View() string {
 
 	content := lipgloss.JoinVertical(lipgloss.Center, header, menuBox, footer)
 	if m.helpVisible {
-		helpBox := styleMenuBox.MaxWidth(contentWidth + 6).Render(menuHelpText(contentWidth))
+		helpBox := styleMenuBox.MaxWidth(contentWidth + 6).Render(menuHelpText(contentWidth, m.config.Title))
 		content = lipgloss.JoinVertical(lipgloss.Center, header, menuBox, helpBox, footer)
 	}
 
@@ -239,9 +239,16 @@ func (m MenuModel) View() string {
 	return lipgloss.Place(viewWidth, m.height, lipgloss.Center, lipgloss.Center, content)
 }
 
-func menuHelpText(width int) string {
+func menuHelpText(width int, screenTitle string) string {
+	title := strings.TrimSpace(screenTitle)
+	if title == "" {
+		title = "Keymap"
+	} else {
+		title += " Keymap"
+	}
+
 	lines := []string{
-		styleBrandStrong.Render("Keymap"),
+		styleBrandStrong.Render(title),
 		styleMuted.Render("up/down or j/k  move selection"),
 		styleMuted.Render("enter           choose item"),
 		styleMuted.Render("esc/q           back/quit"),

--- a/internal/app/menu_model.go
+++ b/internal/app/menu_model.go
@@ -239,6 +239,7 @@ func (m MenuModel) View() string {
 	return lipgloss.Place(viewWidth, m.height, lipgloss.Center, lipgloss.Center, content)
 }
 
+// menuHelpText renders the shared menu keymap panel with screen context.
 func menuHelpText(width int, screenTitle string) string {
 	title := strings.TrimSpace(screenTitle)
 	if title == "" {

--- a/internal/breeze/breeze_ui_test.go
+++ b/internal/breeze/breeze_ui_test.go
@@ -23,6 +23,10 @@ func keyMsg(r rune) tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
 }
 
+func ctrlKMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyCtrlK}
+}
+
 func TestWindowSizeMsgAppliesMinimumViewportAndInputWidth(t *testing.T) {
 	m := breezeModel{
 		textInput: textinput.New(),
@@ -92,6 +96,89 @@ func TestQuestionMarkTogglesHelpAndBlocksNormalProcessing(t *testing.T) {
 	}
 	if m.showHelp {
 		t.Fatal("expected help overlay to be hidden after second ?")
+	}
+}
+
+func TestCtrlKTogglesHelpAndBlocksNormalProcessing(t *testing.T) {
+	m := breezeModel{
+		textInput: textinput.New(),
+		viewport:  viewport.New(20, 4),
+		ready:     true,
+		messages:  []string{"existing message"},
+	}
+	m.textInput.SetValue("/quit")
+
+	m, cmd := updateBreezeModel(t, m, ctrlKMsg())
+	if cmd != nil {
+		t.Fatal("expected no command when toggling help on with ctrl+k")
+	}
+	if !m.showHelp {
+		t.Fatal("expected help overlay to be visible after ctrl+k")
+	}
+
+	prevMsgCount := len(m.messages)
+	m, cmd = updateBreezeModel(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatal("expected enter to be ignored while help is visible")
+	}
+	if !m.showHelp {
+		t.Fatal("expected help overlay to remain visible after ignored key")
+	}
+	if got := len(m.messages); got != prevMsgCount {
+		t.Fatalf("expected no new messages while help is visible: got %d want %d", got, prevMsgCount)
+	}
+
+	m, cmd = updateBreezeModel(t, m, ctrlKMsg())
+	if cmd != nil {
+		t.Fatal("expected no command when toggling help off with ctrl+k")
+	}
+	if m.showHelp {
+		t.Fatal("expected help overlay to be hidden after second ctrl+k")
+	}
+}
+
+func TestHelpOverlayCanBeClosedWithEitherToggleKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		openKey   tea.KeyMsg
+		closeKey  tea.KeyMsg
+		closeHint string
+	}{
+		{
+			name:      "open with question mark, close with ctrl+k",
+			openKey:   keyMsg('?'),
+			closeKey:  ctrlKMsg(),
+			closeHint: "ctrl+k",
+		},
+		{
+			name:      "open with ctrl+k, close with question mark",
+			openKey:   ctrlKMsg(),
+			closeKey:  keyMsg('?'),
+			closeHint: "?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := breezeModel{
+				textInput: textinput.New(),
+				viewport:  viewport.New(20, 4),
+				ready:     true,
+			}
+
+			m, _ = updateBreezeModel(t, m, tt.openKey)
+			if !m.showHelp {
+				t.Fatal("expected help overlay to be visible after open key")
+			}
+
+			m, cmd := updateBreezeModel(t, m, tt.closeKey)
+			if cmd != nil {
+				t.Fatalf("expected no command when closing help with %s", tt.closeHint)
+			}
+			if m.showHelp {
+				t.Fatalf("expected help overlay to be hidden after %s", tt.closeHint)
+			}
+		})
 	}
 }
 

--- a/internal/breeze/breeze_ui_test.go
+++ b/internal/breeze/breeze_ui_test.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// updateBreezeModel applies a tea message and type-asserts the next model.
 func updateBreezeModel(t *testing.T, m breezeModel, msg tea.Msg) (breezeModel, tea.Cmd) {
 	t.Helper()
 	next, cmd := m.Update(msg)
@@ -19,14 +20,17 @@ func updateBreezeModel(t *testing.T, m breezeModel, msg tea.Msg) (breezeModel, t
 	return bm, cmd
 }
 
+// keyMsg builds a rune-based key message for tests.
 func keyMsg(r rune) tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
 }
 
+// ctrlKMsg builds a Ctrl+K key message for help-overlay tests.
 func ctrlKMsg() tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyCtrlK}
 }
 
+// TestWindowSizeMsgAppliesMinimumViewportAndInputWidth validates baseline resize math.
 func TestWindowSizeMsgAppliesMinimumViewportAndInputWidth(t *testing.T) {
 	m := breezeModel{
 		textInput: textinput.New(),
@@ -61,6 +65,7 @@ func TestWindowSizeMsgAppliesMinimumViewportAndInputWidth(t *testing.T) {
 	}
 }
 
+// TestQuestionMarkTogglesHelpAndBlocksNormalProcessing validates '?' overlay behavior.
 func TestQuestionMarkTogglesHelpAndBlocksNormalProcessing(t *testing.T) {
 	m := breezeModel{
 		textInput: textinput.New(),
@@ -99,6 +104,7 @@ func TestQuestionMarkTogglesHelpAndBlocksNormalProcessing(t *testing.T) {
 	}
 }
 
+// TestCtrlKTogglesHelpAndBlocksNormalProcessing validates Ctrl+K parity with '?'.
 func TestCtrlKTogglesHelpAndBlocksNormalProcessing(t *testing.T) {
 	m := breezeModel{
 		textInput: textinput.New(),
@@ -137,6 +143,7 @@ func TestCtrlKTogglesHelpAndBlocksNormalProcessing(t *testing.T) {
 	}
 }
 
+// TestHelpOverlayCanBeClosedWithEitherToggleKey validates mixed-key open/close flows.
 func TestHelpOverlayCanBeClosedWithEitherToggleKey(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -182,6 +189,7 @@ func TestHelpOverlayCanBeClosedWithEitherToggleKey(t *testing.T) {
 	}
 }
 
+// TestViewIncludesHelpHintText ensures discoverability hint is always rendered.
 func TestViewIncludesHelpHintText(t *testing.T) {
 	m := breezeModel{
 		viewport:  viewport.New(40, 10),

--- a/internal/tempest/tempest_ui_test.go
+++ b/internal/tempest/tempest_ui_test.go
@@ -39,6 +39,7 @@ func TestTempestUpdateWindowSizeIgnoresRepeatedTinyResize(t *testing.T) {
 }
 
 // TestTempestHelpToggleParityWithCtrlKAndEnterBlockedWhenOpen verifies toggle-key parity and input blocking.
+// This intentionally runs before any WindowSizeMsg to cover pre-initialized model behavior from initialModel.
 func TestTempestHelpToggleParityWithCtrlKAndEnterBlockedWhenOpen(t *testing.T) {
 	m := initialModel(context.Background(), nil, Options{MCPURL: "http://example.com"})
 

--- a/internal/tempest/tempest_ui_test.go
+++ b/internal/tempest/tempest_ui_test.go
@@ -31,13 +31,13 @@ func TestTempestUpdateWindowSizeAppliesSafeMinimumViewport(t *testing.T) {
 	}
 }
 
-func TestTempestHelpToggleAndEnterBlockedWhenHelpOpen(t *testing.T) {
+func TestTempestHelpToggleParityWithCtrlKAndEnterBlockedWhenOpen(t *testing.T) {
 	m := initialModel(context.Background(), nil, Options{MCPURL: "http://example.com"})
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlK})
 	got := updated.(tempestModel)
 	if !got.showHelp {
-		t.Fatalf("expected help to be shown after '?' toggle")
+		t.Fatalf("expected help to be shown after ctrl+k toggle")
 	}
 
 	updated, cmd := got.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -55,7 +55,19 @@ func TestTempestHelpToggleAndEnterBlockedWhenHelpOpen(t *testing.T) {
 	updated, _ = got.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
 	got = updated.(tempestModel)
 	if got.showHelp {
-		t.Fatalf("expected help to be hidden after second '?' toggle")
+		t.Fatalf("expected help to be hidden after '?' toggle")
+	}
+
+	updated, _ = got.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	got = updated.(tempestModel)
+	if !got.showHelp {
+		t.Fatalf("expected help to be shown after '?' toggle")
+	}
+
+	updated, _ = got.Update(tea.KeyMsg{Type: tea.KeyCtrlK})
+	got = updated.(tempestModel)
+	if got.showHelp {
+		t.Fatalf("expected help to be hidden after ctrl+k toggle")
 	}
 }
 

--- a/internal/tempest/tempest_ui_test.go
+++ b/internal/tempest/tempest_ui_test.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// TestTempestUpdateWindowSizeAppliesSafeMinimumViewport verifies minimum viewport bounds.
 func TestTempestUpdateWindowSizeAppliesSafeMinimumViewport(t *testing.T) {
 	m := initialModel(context.Background(), nil, Options{MCPURL: "http://example.com"})
 
@@ -31,6 +32,7 @@ func TestTempestUpdateWindowSizeAppliesSafeMinimumViewport(t *testing.T) {
 	}
 }
 
+// TestTempestHelpToggleParityWithCtrlKAndEnterBlockedWhenOpen verifies toggle-key parity and input blocking.
 func TestTempestHelpToggleParityWithCtrlKAndEnterBlockedWhenOpen(t *testing.T) {
 	m := initialModel(context.Background(), nil, Options{MCPURL: "http://example.com"})
 
@@ -71,6 +73,7 @@ func TestTempestHelpToggleParityWithCtrlKAndEnterBlockedWhenOpen(t *testing.T) {
 	}
 }
 
+// TestTempestViewIncludesHelpHintText ensures the help discoverability hint is visible.
 func TestTempestViewIncludesHelpHintText(t *testing.T) {
 	m := initialModel(context.Background(), nil, Options{MCPURL: "http://example.com"})
 

--- a/test/lighthouse_menu_test.go
+++ b/test/lighthouse_menu_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/alibilge/dirstral-cli/internal/app"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestLighthouseMenuItemsOrder(t *testing.T) {
@@ -22,5 +23,27 @@ func TestLighthouseMenuControlsAreKeyboardFirst(t *testing.T) {
 	}
 	if !strings.Contains(cfg.Controls, "esc/q") {
 		t.Fatalf("expected esc/q controls, got %q", cfg.Controls)
+	}
+}
+
+func TestLighthouseMenuHelpOverlayToggleVisibility(t *testing.T) {
+	m := app.NewMenuModel(app.LighthouseMenuConfig())
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 90, Height: 28})
+	m = updated.(app.MenuModel)
+
+	if strings.Contains(m.View(), "Lighthouse Keymap") {
+		t.Fatalf("expected help overlay hidden by default")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	withHelp := updated.(app.MenuModel)
+	if !strings.Contains(withHelp.View(), "Lighthouse Keymap") {
+		t.Fatalf("expected help overlay visible after ?")
+	}
+
+	updated, _ = withHelp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	withoutHelp := updated.(app.MenuModel)
+	if strings.Contains(withoutHelp.View(), "Lighthouse Keymap") {
+		t.Fatalf("expected help overlay hidden after second ?")
 	}
 }

--- a/test/lighthouse_menu_test.go
+++ b/test/lighthouse_menu_test.go
@@ -26,6 +26,7 @@ func TestLighthouseMenuControlsAreKeyboardFirst(t *testing.T) {
 	}
 }
 
+// TestLighthouseMenuHelpOverlayToggleVisibility verifies help visibility toggles in Lighthouse menu.
 func TestLighthouseMenuHelpOverlayToggleVisibility(t *testing.T) {
 	m := app.NewMenuModel(app.LighthouseMenuConfig())
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 90, Height: 28})

--- a/test/menu_test.go
+++ b/test/menu_test.go
@@ -125,14 +125,50 @@ func TestMenuHelpOverlayToggle(t *testing.T) {
 
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
 	withHelp := updated.(app.MenuModel)
-	if !strings.Contains(withHelp.View(), "Keymap") {
+	if !strings.Contains(withHelp.View(), "Welcome to Dirstral Keymap") {
 		t.Fatalf("expected help overlay to show keymap")
 	}
 
 	updated, _ = withHelp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
 	withoutHelp := updated.(app.MenuModel)
-	if strings.Contains(withoutHelp.View(), "Keymap") {
+	if strings.Contains(withoutHelp.View(), "Welcome to Dirstral Keymap") {
 		t.Fatalf("expected help overlay to close after second ?")
+	}
+}
+
+func TestMenuHelpOverlayBlocksEnterSelection(t *testing.T) {
+	m := app.NewMenuModel(app.StartMenuConfig())
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 90, Height: 28})
+	m = updated.(app.MenuModel)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	withHelp := updated.(app.MenuModel)
+
+	updated, cmd := withHelp.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	afterEnter := updated.(app.MenuModel)
+	if afterEnter.Chosen() != "" {
+		t.Fatalf("expected no selection when help overlay is open, got %q", afterEnter.Chosen())
+	}
+	if cmd != nil {
+		t.Fatalf("expected no quit command when help overlay is open")
+	}
+}
+
+func TestMenuHelpOverlayCtrlKToggle(t *testing.T) {
+	m := app.NewMenuModel(app.StartMenuConfig())
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 90, Height: 28})
+	m = updated.(app.MenuModel)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlK})
+	withHelp := updated.(app.MenuModel)
+	if !strings.Contains(withHelp.View(), "Welcome to Dirstral Keymap") {
+		t.Fatalf("expected help overlay to open on ctrl+k")
+	}
+
+	updated, _ = withHelp.Update(tea.KeyMsg{Type: tea.KeyCtrlK})
+	withoutHelp := updated.(app.MenuModel)
+	if strings.Contains(withoutHelp.View(), "Welcome to Dirstral Keymap") {
+		t.Fatalf("expected help overlay to close on second ctrl+k")
 	}
 }
 

--- a/test/menu_test.go
+++ b/test/menu_test.go
@@ -118,6 +118,7 @@ func TestMenuViewIncludesHelpHint(t *testing.T) {
 	}
 }
 
+// TestMenuHelpOverlayToggle ensures '?' toggles the shared menu keymap overlay.
 func TestMenuHelpOverlayToggle(t *testing.T) {
 	m := app.NewMenuModel(app.StartMenuConfig())
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 90, Height: 28})
@@ -136,6 +137,7 @@ func TestMenuHelpOverlayToggle(t *testing.T) {
 	}
 }
 
+// TestMenuHelpOverlayBlocksEnterSelection ensures Enter is ignored while overlay is open.
 func TestMenuHelpOverlayBlocksEnterSelection(t *testing.T) {
 	m := app.NewMenuModel(app.StartMenuConfig())
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 90, Height: 28})
@@ -154,6 +156,7 @@ func TestMenuHelpOverlayBlocksEnterSelection(t *testing.T) {
 	}
 }
 
+// TestMenuHelpOverlayCtrlKToggle ensures Ctrl+K toggles the shared menu keymap overlay.
 func TestMenuHelpOverlayCtrlKToggle(t *testing.T) {
 	m := app.NewMenuModel(app.StartMenuConfig())
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 90, Height: 28})


### PR DESCRIPTION
## Summary
- make shared menu help overlay context-aware by rendering screen-specific keymap titles (for example, Welcome vs Lighthouse)
- add regression tests for shared menu behavior: `?` toggle, `ctrl+k` toggle, and enter-key blocking while help overlay is open
- add Breeze and Tempest parity tests to verify `ctrl+k` behaves the same as `?` and active flows remain protected while help is visible

## Validation
- go test ./...
- go build -o bin/dirstral ./cmd/dirstral

## Notes
- local `make lint` cannot run in this environment because `golangci-lint` is not installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+K parity with ? to toggle the help overlay.
  * Help overlay title now reflects the current screen title (e.g., "Welcome to ... Keymap").

* **Bug Fixes**
  * Help overlay blocks normal input (Enter and other commands) while open.
  * Viewport/layout recomputes correctly when help is toggled on small terminals.

* **Tests**
  * Added/updated tests for toggle parity, blocking behavior, dynamic title, and viewport handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->