### PR TITLE
feat: implement #26 manifest command and #27 mode-flow smoke tests

### DIFF
--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alibilge/dirstral-cli/internal/breeze"
 	"github.com/alibilge/dirstral-cli/internal/config"
 	"github.com/alibilge/dirstral-cli/internal/host"
+	"github.com/alibilge/dirstral-cli/internal/mcp"
 	"github.com/alibilge/dirstral-cli/internal/tempest"
 	"github.com/spf13/cobra"
 )
@@ -57,6 +58,7 @@ func newRootCommand(cfg config.Config) *cobra.Command {
 	root.AddCommand(newBreezeCommand(cfg))
 	root.AddCommand(newTempestCommand(cfg))
 	root.AddCommand(newLighthouseCommand(cfg))
+	root.AddCommand(newManifestCommand(cfg))
 	return root
 }
 
@@ -206,13 +208,67 @@ func newLighthouseCommand(cfg config.Config) *cobra.Command {
 	return cmd
 }
 
+func newManifestCommand(cfg config.Config) *cobra.Command {
+	var mcpURL string
+	var transport string
+	var asJSON bool
+	var verbose bool
+
+	mcpURL = cfg.MCP.URL
+	transport = cfg.MCP.Transport
+	verbose = cfg.Verbose
+
+	cmd := &cobra.Command{
+		Use:   "manifest",
+		Short: "Print MCP capability manifest",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolvedMCPURL := ResolveMCPURL(cfg.MCP.URL, mcpURL, cmd.Flags().Changed("mcp"), transport)
+			client := mcp.NewWithTransport(resolvedMCPURL, transport, verbose)
+			defer func() {
+				_ = client.Close()
+			}()
+
+			if err := client.Initialize(cmd.Context()); err != nil {
+				return fmt.Errorf("mcp initialize failed: %w", err)
+			}
+			manifest, err := mcp.BuildCapabilityManifest(cmd.Context(), client)
+			if err != nil {
+				return fmt.Errorf("manifest build failed: %w", err)
+			}
+
+			if asJSON {
+				payload, err := mcp.RenderCapabilityManifestJSON(manifest)
+				if err != nil {
+					return fmt.Errorf("manifest render failed: %w", err)
+				}
+				fmt.Println(string(payload))
+				return nil
+			}
+
+			fmt.Println(mcp.RenderCapabilityManifestHuman(manifest))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&mcpURL, "mcp", mcpURL, "MCP server URL (streamable-http) or stdio command")
+	cmd.Flags().StringVar(&transport, "transport", transport, "MCP transport (streamable-http|stdio)")
+	cmd.Flags().BoolVar(&asJSON, "json", asJSON, "Print JSON manifest")
+	cmd.Flags().BoolVar(&verbose, "verbose", verbose, "Verbose MCP logging")
+	return cmd
+}
+
 func runBreeze(ctx context.Context, cfg config.Config) error {
 	mcpURL := ResolveMCPURL(cfg.MCP.URL, "", false, cfg.MCP.Transport)
 	return breeze.Run(ctx, breeze.Options{MCPURL: mcpURL, Transport: cfg.MCP.Transport, Model: cfg.Model, Verbose: cfg.Verbose})
 }
 
 func ResolveMCPURL(defaultURL, explicitURL string, explicitOverride bool, transport string) string {
+	defaultURL = strings.TrimSpace(defaultURL)
+	explicitURL = strings.TrimSpace(explicitURL)
 	if explicitOverride {
+		if explicitURL == "" {
+			return defaultURL
+		}
 		return explicitURL
 	}
 	if strings.EqualFold(strings.TrimSpace(transport), "stdio") {

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -90,6 +90,7 @@ func New(endpoint string, verbose bool) *Client {
 }
 
 func NewWithTransport(endpoint, transport string, verbose bool) *Client {
+	endpoint = strings.TrimSpace(endpoint)
 	transport = strings.TrimSpace(strings.ToLower(transport))
 	if transport == "" {
 		transport = "streamable-http"
@@ -184,6 +185,7 @@ func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
 		tools = append(tools, Tool{
 			Name:        asString(m["name"]),
 			Description: asString(m["description"]),
+			InputSchema: asMap(m["inputSchema"]),
 		})
 	}
 	return tools, nil
@@ -323,6 +325,13 @@ func (c *Client) call(ctx context.Context, method string, params map[string]any,
 
 	var envelope jsonRPCResponse
 	if err := json.Unmarshal(bodyBytes, &envelope); err != nil {
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			bodyText := strings.TrimSpace(string(bodyBytes))
+			if bodyText == "" {
+				bodyText = http.StatusText(resp.StatusCode)
+			}
+			return nil, resp.StatusCode, resp.Header, fmt.Errorf("http status %d: %s", resp.StatusCode, bodyText)
+		}
 		return nil, resp.StatusCode, resp.Header, err
 	}
 	if envelope.Error != nil {
@@ -469,4 +478,9 @@ func asString(v any) string {
 func asBool(v any) bool {
 	b, _ := v.(bool)
 	return b
+}
+
+func asMap(v any) map[string]any {
+	m, _ := v.(map[string]any)
+	return m
 }

--- a/internal/mcp/manifest.go
+++ b/internal/mcp/manifest.go
@@ -101,7 +101,11 @@ func sanitizeEndpoint(raw string) string {
 		return ""
 	}
 	if !strings.Contains(trimmed, "://") {
-		return trimmed
+		parts := strings.Fields(trimmed)
+		if len(parts) <= 1 {
+			return trimmed
+		}
+		return parts[0] + " <redacted>"
 	}
 	u, err := url.Parse(trimmed)
 	if err != nil {

--- a/internal/mcp/manifest.go
+++ b/internal/mcp/manifest.go
@@ -1,0 +1,114 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+type ToolManifest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	HasSchema   bool   `json:"has_schema"`
+}
+
+type EndpointManifest struct {
+	Endpoint        string `json:"endpoint"`
+	Transport       string `json:"transport"`
+	ProtocolVersion string `json:"protocol_version"`
+	SessionID       string `json:"session_id,omitempty"`
+}
+
+type CapabilityManifest struct {
+	GeneratedAt time.Time        `json:"generated_at"`
+	Endpoint    EndpointManifest `json:"endpoint"`
+	Tools       []ToolManifest   `json:"tools"`
+}
+
+func BuildCapabilityManifest(ctx context.Context, client *Client) (CapabilityManifest, error) {
+	if client == nil {
+		return CapabilityManifest{}, fmt.Errorf("mcp client is nil")
+	}
+	tools, err := client.ListTools(ctx)
+	if err != nil {
+		return CapabilityManifest{}, fmt.Errorf("tools/list failed: %w", err)
+	}
+	manifestTools := make([]ToolManifest, 0, len(tools))
+	for _, tool := range tools {
+		manifestTools = append(manifestTools, ToolManifest{
+			Name:        tool.Name,
+			Description: strings.TrimSpace(tool.Description),
+			HasSchema:   tool.InputSchema != nil,
+		})
+	}
+	sort.Slice(manifestTools, func(i, j int) bool {
+		return manifestTools[i].Name < manifestTools[j].Name
+	})
+
+	return CapabilityManifest{
+		GeneratedAt: time.Now().UTC(),
+		Endpoint: EndpointManifest{
+			Endpoint:        sanitizeEndpoint(client.endpoint),
+			Transport:       strings.TrimSpace(client.transport),
+			ProtocolVersion: protocolVersion,
+			SessionID:       strings.TrimSpace(client.sessionID),
+		},
+		Tools: manifestTools,
+	}, nil
+}
+
+func RenderCapabilityManifestHuman(manifest CapabilityManifest) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Generated: %s\n", manifest.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(&b, "Endpoint: %s\n", orUnknown(manifest.Endpoint.Endpoint))
+	fmt.Fprintf(&b, "Transport: %s\n", orUnknown(manifest.Endpoint.Transport))
+	fmt.Fprintf(&b, "Protocol: %s\n", orUnknown(manifest.Endpoint.ProtocolVersion))
+	fmt.Fprintf(&b, "Session: %s\n", orUnknown(manifest.Endpoint.SessionID))
+	fmt.Fprintf(&b, "Tools (%d):\n", len(manifest.Tools))
+	for _, tool := range manifest.Tools {
+		desc := strings.TrimSpace(tool.Description)
+		if desc == "" {
+			desc = "(no description)"
+		}
+		schema := "no"
+		if tool.HasSchema {
+			schema = "yes"
+		}
+		fmt.Fprintf(&b, "- %s\n  schema: %s\n  description: %s\n", tool.Name, schema, desc)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func RenderCapabilityManifestJSON(manifest CapabilityManifest) ([]byte, error) {
+	return json.MarshalIndent(manifest, "", "  ")
+}
+
+func orUnknown(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "unknown"
+	}
+	return v
+}
+
+func sanitizeEndpoint(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if !strings.Contains(trimmed, "://") {
+		return trimmed
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}

--- a/tests/mode_flow_test.go
+++ b/tests/mode_flow_test.go
@@ -1,0 +1,283 @@
+package test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/alibilge/dirstral-cli/internal/app"
+	"github.com/alibilge/dirstral-cli/internal/breeze"
+	"github.com/alibilge/dirstral-cli/internal/config"
+	"github.com/alibilge/dirstral-cli/internal/host"
+	"github.com/alibilge/dirstral-cli/internal/mcp"
+)
+
+func TestModeFlowSmokeLighthouseToBreezeToTempestHandoff(t *testing.T) {
+	setTestConfigDir(t)
+	_ = host.ClearState()
+	t.Cleanup(func() {
+		_ = host.ClearState()
+	})
+
+	server, calls := newModeFlowMCPServer(t)
+	defer server.Close()
+
+	activeEndpoint := server.URL
+	staleConfigEndpoint := "http://127.0.0.1:1/mcp"
+
+	requireNoErrSegment(t, "host", host.SaveState(host.State{
+		PID:       os.Getpid(),
+		StartedAt: "now",
+		MCPURL:    activeEndpoint,
+	}))
+
+	health := host.CheckHealth()
+	if !health.Ready {
+		t.Fatalf("host segment: expected active lighthouse endpoint to be ready, got ready=%v reachable=%v mcp_ready=%v detail=%q", health.Ready, health.Reachable, health.MCPReady, health.LastError)
+	}
+
+	breezeURL := app.ResolveMCPURL(staleConfigEndpoint, "", false, "streamable-http")
+	if breezeURL != activeEndpoint {
+		t.Fatalf("breeze segment: expected handoff endpoint %q from lighthouse, got %q", activeEndpoint, breezeURL)
+	}
+
+	client := mcp.NewWithTransport(breezeURL, "streamable-http", false)
+	defer func() {
+		_ = client.Close()
+	}()
+	requireNoErrSegment(t, "breeze", client.Initialize(context.Background()))
+
+	in := bytes.NewBufferString("/list src\n/quit\n")
+	out := &bytes.Buffer{}
+	breezeOpts := breeze.Options{
+		MCPURL:    breezeURL,
+		Transport: "streamable-http",
+		Model:     "mistral-small-latest",
+		JSON:      true,
+	}
+	requireNoErrSegment(t, "breeze", breeze.RunJSONLoopWithIO(context.Background(), client, breezeOpts, in, out))
+
+	events := decodeModeFlowEvents(t, "breeze", out.Bytes())
+	if len(events) < 3 {
+		t.Fatalf("breeze segment: expected at least 3 events (session/tool_result/exit), got %d", len(events))
+	}
+
+	var sawToolResult bool
+	for _, evt := range events {
+		typ, _ := evt["type"].(string)
+		if typ != "tool_result" {
+			continue
+		}
+		data, _ := evt["data"].(map[string]any)
+		if data["tool"] == "dir2mcp.list_files" {
+			sawToolResult = true
+			break
+		}
+	}
+	if !sawToolResult {
+		t.Fatalf("breeze segment: expected tool_result for dir2mcp.list_files")
+	}
+
+	if !calls.HasToolCall("dir2mcp.list_files") {
+		t.Fatalf("breeze segment: expected MCP tools/call for dir2mcp.list_files, got calls=%v", calls.ToolCalls())
+	}
+
+	cfg := config.Default()
+	cfg.MCP.URL = staleConfigEndpoint
+
+	tempestURL := app.ResolveMCPURL(cfg.MCP.URL, "", false, cfg.MCP.Transport)
+	if tempestURL != activeEndpoint {
+		t.Fatalf("tempest segment: expected handoff endpoint %q from lighthouse, got %q", activeEndpoint, tempestURL)
+	}
+
+	tempestOpts := app.BuildTempestOptions(cfg, tempestURL, "", "", true, false, "")
+	if tempestOpts.MCPURL != activeEndpoint {
+		t.Fatalf("tempest segment: expected options MCPURL %q, got %q", activeEndpoint, tempestOpts.MCPURL)
+	}
+	if tempestOpts.Transport != cfg.MCP.Transport {
+		t.Fatalf("tempest segment: expected transport %q, got %q", cfg.MCP.Transport, tempestOpts.Transport)
+	}
+}
+
+func TestModeFlowPrefersActiveEndpointOverStaleConfig(t *testing.T) {
+	setTestConfigDir(t)
+	_ = host.ClearState()
+	t.Cleanup(func() {
+		_ = host.ClearState()
+	})
+
+	server, _ := newModeFlowMCPServer(t)
+	defer server.Close()
+
+	activeEndpoint := server.URL
+	staleConfigEndpoint := "http://127.0.0.1:2/mcp"
+
+	requireNoErrSegment(t, "host", host.SaveState(host.State{
+		PID:       os.Getpid(),
+		StartedAt: "now",
+		MCPURL:    activeEndpoint,
+	}))
+
+	health := host.CheckHealth()
+	if !health.Ready {
+		t.Fatalf("host segment: expected lighthouse ready for runtime endpoint preference check, got ready=%v detail=%q", health.Ready, health.LastError)
+	}
+
+	resolved := app.ResolveMCPURL(staleConfigEndpoint, "", false, "streamable-http")
+	if resolved != activeEndpoint {
+		t.Fatalf("breeze segment: expected runtime endpoint %q to override stale config %q, got %q", activeEndpoint, staleConfigEndpoint, resolved)
+	}
+
+	cfg := config.Default()
+	cfg.MCP.URL = staleConfigEndpoint
+	tempestOpts := app.BuildTempestOptions(cfg, resolved, "", "", true, false, "")
+	if tempestOpts.MCPURL != activeEndpoint {
+		t.Fatalf("tempest segment: expected runtime endpoint %q to override stale config %q, got %q", activeEndpoint, staleConfigEndpoint, tempestOpts.MCPURL)
+	}
+}
+
+func requireNoErrSegment(t *testing.T, segment string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s segment: unexpected error: %v", segment, err)
+	}
+}
+
+func decodeModeFlowEvents(t *testing.T, segment string, payload []byte) []map[string]any {
+	t.Helper()
+
+	scanner := bufio.NewScanner(bytes.NewReader(payload))
+	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+	events := make([]map[string]any, 0)
+	for scanner.Scan() {
+		evt := map[string]any{}
+		if err := json.Unmarshal(scanner.Bytes(), &evt); err != nil {
+			t.Fatalf("%s segment: invalid json event: %v", segment, err)
+		}
+		events = append(events, evt)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("%s segment: failed to scan events: %v", segment, err)
+	}
+	return events
+}
+
+type modeFlowCalls struct {
+	mu        sync.Mutex
+	toolCalls []string
+}
+
+func (m *modeFlowCalls) recordToolCall(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.toolCalls = append(m.toolCalls, name)
+}
+
+func (m *modeFlowCalls) HasToolCall(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, got := range m.toolCalls {
+		if got == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *modeFlowCalls) ToolCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	copyCalls := make([]string, len(m.toolCalls))
+	copy(copyCalls, m.toolCalls)
+	return copyCalls
+}
+
+func newModeFlowMCPServer(t *testing.T) (*httptest.Server, *modeFlowCalls) {
+	t.Helper()
+
+	const sessionID = "sess-mode-flow"
+	calls := &modeFlowCalls{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			_ = r.Body.Close()
+		}()
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		req := map[string]any{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		method, _ := req["method"].(string)
+		id := req["id"]
+
+		switch method {
+		case "initialize":
+			w.Header().Set("MCP-Session-Id", sessionID)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result":  map[string]any{"capabilities": map[string]any{"tools": map[string]any{}}},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			if r.Header.Get("MCP-Session-Id") != sessionID {
+				http.Error(w, "unknown session", http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result": map[string]any{
+					"tools": []map[string]any{
+						{"name": "dir2mcp.list_files", "description": "list files"},
+						{"name": "dir2mcp.search", "description": "search"},
+						{"name": "dir2mcp.open_file", "description": "open file"},
+						{"name": "dir2mcp.stats", "description": "stats"},
+						{"name": "dir2mcp.ask", "description": "ask"},
+					},
+				},
+			})
+		case "tools/call":
+			if r.Header.Get("MCP-Session-Id") != sessionID {
+				http.Error(w, "unknown session", http.StatusNotFound)
+				return
+			}
+			params, _ := req["params"].(map[string]any)
+			name, _ := params["name"].(string)
+			calls.recordToolCall(name)
+
+			result := map[string]any{"isError": false, "content": []map[string]any{{"type": "text", "text": "ok"}}}
+			if name == "dir2mcp.list_files" {
+				result["structuredContent"] = map[string]any{
+					"files": []map[string]any{{"rel_path": "src/main.go", "kind": "text"}},
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result":  result,
+			})
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+
+	return server, calls
+}


### PR DESCRIPTION
## Summary
- add a new `dirstral manifest` command that connects to a live MCP endpoint, initializes a session, and prints a capability manifest in human-readable or JSON form
- parse and retain `inputSchema` from `tools/list` responses, and improve MCP client robustness for trimmed endpoints and clearer non-2xx HTTP error surfaces
- add deterministic end-to-end mode-flow smoke coverage for Lighthouse -> Breeze -> Tempest handoff, including stale-config runtime-endpoint preference checks

## Validation
- `make lint` (fails locally because `golangci-lint` is not installed in this environment)
- `gofmt -w internal/app/root.go internal/mcp/client.go internal/mcp/manifest.go tests/mode_flow_test.go`
- `go build ./...`
- `go test ./...`

Closes #26
Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manifest command to generate MCP capability manifests (JSON or human-readable), including sanitized endpoint and tool schema info; supports verbose logging.
  * Improved endpoint normalization and transport defaulting for MCP clients.

* **Bug Fixes**
  * Better error messages for failed API calls (includes status and response body).
  * Trimmed/normalized URL handling and explicit-override precedence.

* **Tests**
  * New integration tests for mode-flow behavior and endpoint handoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->