### PR TITLE
feat: in-CLI settings editor and lighthouse log viewer (#29)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -125,6 +125,7 @@ func (m *appModel) updateDynamicItems(msg lighthouseStatusMsg) {
 		if msg.Health.Alive {
 			items = []MenuItem{
 				{Label: lighthouseActionStatus, Description: "Check process and endpoint health", Value: lighthouseActionStatus},
+				{Label: lighthouseActionLogs, Description: "Tail dir2mcp output", Value: lighthouseActionLogs},
 				{Label: lighthouseActionStop, Description: "Terminate managed dir2mcp", Value: lighthouseActionStop},
 				{Label: lighthouseActionBack, Description: "Return to main menu", Value: lighthouseActionBack},
 			}

--- a/internal/app/lighthouse_logs.go
+++ b/internal/app/lighthouse_logs.go
@@ -90,10 +90,9 @@ func (m logModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	var cmd tea.Cmd
-	prevAtBottom := m.viewport.AtBottom()
 	m.viewport, cmd = m.viewport.Update(msg)
 	// Track whether user is at the bottom after any viewport movement.
-	m.wasAtBottom = prevAtBottom
+	m.wasAtBottom = m.viewport.AtBottom()
 	return m, cmd
 }
 

--- a/internal/app/lighthouse_logs.go
+++ b/internal/app/lighthouse_logs.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/alibilge/dirstral-cli/internal/host"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const (
+	logMaxLines     = 100
+	logTickInterval = 500 * time.Millisecond
+)
+
+type logTickMsg time.Time
+
+type logModel struct {
+	viewport     viewport.Model
+	logPath      string
+	lastSize     int64
+	content      string
+	ready        bool
+	width        int
+	height       int
+	wasAtBottom  bool
+	emptyMessage string
+}
+
+func newLogModel() logModel {
+	logPath := host.LogPath()
+	return logModel{
+		logPath:      logPath,
+		wasAtBottom:  true,
+		emptyMessage: "No log output yet. Start a server first.",
+	}
+}
+
+func (m logModel) Init() tea.Cmd {
+	return tea.Batch(tickLogs(), m.loadLogs)
+}
+
+func tickLogs() tea.Cmd {
+	return tea.Tick(logTickInterval, func(t time.Time) tea.Msg {
+		return logTickMsg(t)
+	})
+}
+
+func (m logModel) loadLogs() tea.Msg {
+	return logTickMsg(time.Now())
+}
+
+func (m logModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc":
+			return m, tea.Quit
+		case "G":
+			m.viewport.GotoBottom()
+			m.wasAtBottom = true
+			return m, nil
+		}
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		headerHeight := 2 // header + blank line
+		footerHeight := 2 // blank line + footer
+		viewportHeight := m.height - headerHeight - footerHeight
+		if viewportHeight < 1 {
+			viewportHeight = 1
+		}
+		if !m.ready {
+			m.viewport = viewport.New(m.width, viewportHeight)
+			m.viewport.SetContent(m.content)
+			m.ready = true
+		} else {
+			m.viewport.Width = m.width
+			m.viewport.Height = viewportHeight
+		}
+		return m, nil
+
+	case logTickMsg:
+		m.refreshContent()
+		return m, tickLogs()
+	}
+
+	var cmd tea.Cmd
+	prevAtBottom := m.viewport.AtBottom()
+	m.viewport, cmd = m.viewport.Update(msg)
+	// Track whether user is at the bottom after any viewport movement.
+	m.wasAtBottom = prevAtBottom
+	return m, cmd
+}
+
+func (m *logModel) refreshContent() {
+	info, err := os.Stat(m.logPath)
+	if err != nil || info.Size() == 0 {
+		m.content = styleMuted.Render(m.emptyMessage)
+		m.lastSize = 0
+		if m.ready {
+			m.viewport.SetContent(m.content)
+		}
+		return
+	}
+
+	// Only re-read if file size changed.
+	if info.Size() == m.lastSize {
+		return
+	}
+	m.lastSize = info.Size()
+
+	data, err := os.ReadFile(m.logPath)
+	if err != nil {
+		m.content = styleMuted.Render("Error reading log file: " + err.Error())
+		if m.ready {
+			m.viewport.SetContent(m.content)
+		}
+		return
+	}
+
+	m.content = TailLogLines(string(data), logMaxLines)
+	if m.ready {
+		m.viewport.SetContent(m.content)
+		if m.wasAtBottom {
+			m.viewport.GotoBottom()
+		}
+	}
+}
+
+func TailLogLines(raw string, maxLines int) string {
+	trimmed := strings.TrimRight(raw, "\n")
+	if trimmed == "" {
+		return ""
+	}
+	lines := strings.Split(trimmed, "\n")
+	if maxLines > 0 && len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m logModel) View() string {
+	if !m.ready {
+		return styleMuted.Render("Loading...")
+	}
+
+	header := fmt.Sprintf("%s  %s",
+		styleBrandStrong.Render("Lighthouse Logs"),
+		styleSubtle.Render(m.logPath),
+	)
+	footer := styleMuted.Render("q/esc back · up/down scroll · G end")
+
+	return header + "\n\n" + m.viewport.View() + "\n\n" + footer
+}
+
+func runLogViewer() error {
+	model := newLogModel()
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}

--- a/internal/app/lighthouse_menu.go
+++ b/internal/app/lighthouse_menu.go
@@ -3,10 +3,11 @@ package app
 const (
 	lighthouseActionStart  = "Start Server"
 	lighthouseActionStatus = "Server Status"
+	lighthouseActionLogs   = "View Logs"
 	lighthouseActionStop   = "Stop Server"
 	lighthouseActionBack   = "Back"
 )
 
 func LighthouseMenuItems() []string {
-	return []string{lighthouseActionStart, lighthouseActionStatus, lighthouseActionStop, lighthouseActionBack}
+	return []string{lighthouseActionStart, lighthouseActionStatus, lighthouseActionLogs, lighthouseActionStop, lighthouseActionBack}
 }

--- a/internal/app/menu.go
+++ b/internal/app/menu.go
@@ -43,6 +43,7 @@ const (
 	ChoiceBreeze     StartChoice = "Breeze"
 	ChoiceTempest    StartChoice = "Tempest"
 	ChoiceLighthouse StartChoice = "Lighthouse"
+	ChoiceSettings   StartChoice = "Settings"
 	ChoiceQuit       StartChoice = "Exit"
 )
 
@@ -55,7 +56,7 @@ const (
 )
 
 func StartMenuItems() []string {
-	return []string{string(ChoiceBreeze), string(ChoiceTempest), string(ChoiceLighthouse), string(ChoiceQuit)}
+	return []string{string(ChoiceBreeze), string(ChoiceTempest), string(ChoiceLighthouse), string(ChoiceSettings), string(ChoiceQuit)}
 }
 
 func ChooseTier(width int) LogoTier {

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alibilge/dirstral-cli/internal/config"
 	"github.com/alibilge/dirstral-cli/internal/host"
 	"github.com/alibilge/dirstral-cli/internal/mcp"
+	"github.com/alibilge/dirstral-cli/internal/settings"
 	"github.com/alibilge/dirstral-cli/internal/tempest"
 	"github.com/spf13/cobra"
 )
@@ -47,6 +48,15 @@ func newRootCommand(cfg config.Config) *cobra.Command {
 					if err := runLighthouseMenu(cfg); err != nil {
 						printUIError(err)
 					}
+				case ChoiceSettings:
+					printModeHeader("Settings")
+					err := settings.Run(cfg)
+					if refreshed, loadErr := config.Load(); loadErr == nil {
+						cfg = refreshed
+					} else {
+						printUIError(fmt.Errorf("reload config: %w", loadErr))
+					}
+					printModeFeedback("Settings", err)
 				default:
 					fmt.Println(styleMuted.Render("bye"))
 					return nil
@@ -326,6 +336,13 @@ func runLighthouseMenu(cfg config.Config) error {
 			printModeHeader("Lighthouse / Server Status")
 			if err := host.Status(); err != nil {
 				printModeFeedbackTo("Lighthouse status", err, "Lighthouse menu")
+				continue
+			}
+			printReturnTo("Lighthouse menu")
+		case lighthouseActionLogs:
+			printModeHeader("Lighthouse / Logs")
+			if err := runLogViewer(); err != nil {
+				printModeFeedbackTo("Lighthouse logs", err, "Lighthouse menu")
 				continue
 			}
 			printReturnTo("Lighthouse menu")

--- a/internal/app/start_screen.go
+++ b/internal/app/start_screen.go
@@ -37,6 +37,7 @@ func StartMenuConfig() MenuConfig {
 			{Label: string(ChoiceBreeze), Description: "Interactive text chat with MCP tools", Value: string(ChoiceBreeze)},
 			{Label: string(ChoiceTempest), Description: "Voice-powered agent loop", Value: string(ChoiceTempest)},
 			{Label: string(ChoiceLighthouse), Description: "Host and monitor dir2mcp server", Value: string(ChoiceLighthouse)},
+			{Label: string(ChoiceSettings), Description: "Edit config and API settings", Value: string(ChoiceSettings)},
 			{Label: "Exit", Description: "Exit Dirstral", Value: string(ChoiceQuit)},
 		},
 		ShowLogo: true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,6 +224,16 @@ var fieldDefs = []fieldDef{
 	{Key: "ELEVENLABS_API_KEY", EnvVar: "ELEVENLABS_API_KEY", Sensitive: true},
 }
 
+// EnvVarForField returns the environment variable mapped to a field key.
+func EnvVarForField(key string) string {
+	for _, fd := range fieldDefs {
+		if fd.Key == key {
+			return fd.EnvVar
+		}
+	}
+	return ""
+}
+
 // fieldValueFromConfig extracts a config field value by key name.
 func fieldValueFromConfig(cfg Config, key string) string {
 	switch key {
@@ -373,6 +383,10 @@ func ValidateField(key, value string) error {
 	case "elevenlabs.voice":
 		if strings.TrimSpace(value) == "" {
 			return errors.New("elevenlabs.voice must not be empty")
+		}
+	case "DIR2MCP_AUTH_TOKEN", "ELEVENLABS_API_KEY":
+		if value != "" && strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s must not be whitespace-only", key)
 		}
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +11,25 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/joho/godotenv"
 )
+
+// FieldSource indicates where a config value originates.
+type FieldSource string
+
+const (
+	SourceDefault     FieldSource = "default"
+	SourceConfigFile  FieldSource = "config.toml"
+	SourceDotEnv      FieldSource = ".env"
+	SourceDotEnvLocal FieldSource = ".env.local"
+	SourceEnv         FieldSource = "env"
+)
+
+// FieldInfo describes a single configurable field and its provenance.
+type FieldInfo struct {
+	Key       string
+	Value     string
+	Source    FieldSource
+	Sensitive bool
+}
 
 type Config struct {
 	MCP        MCPConfig        `toml:"mcp"`
@@ -138,4 +159,248 @@ func mergeEnv(cfg *Config) {
 	if v := strings.TrimSpace(os.Getenv("DIRSTRAL_HOST_MCP_PATH")); v != "" {
 		cfg.Host.MCPPath = v
 	}
+}
+
+// ConfigPath returns the path to the user's config.toml file.
+func ConfigPath() (string, error) {
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "dirstral", "config.toml"), nil
+}
+
+// Save writes the config to ~/.config/dirstral/config.toml.
+func Save(cfg Config) error {
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	if err := enc.Encode(cfg); err != nil {
+		return fmt.Errorf("encoding config: %w", err)
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}
+
+// SaveSecret writes a key=value pair into .env.local.
+// If the key already exists it is updated; otherwise it is appended.
+// The environment variable is also set in the current process.
+func SaveSecret(key, value string) error {
+	const path = ".env.local"
+	env := map[string]string{}
+	existing, err := godotenv.Read(path)
+	if err == nil {
+		env = existing
+	}
+	env[key] = value
+	if err := godotenv.Write(env, path); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return os.Setenv(key, value)
+}
+
+// fieldDef describes a configurable field for EffectiveFields.
+type fieldDef struct {
+	Key       string
+	EnvVar    string
+	Sensitive bool
+}
+
+var fieldDefs = []fieldDef{
+	{Key: "mcp.url", EnvVar: "DIRSTRAL_MCP_URL"},
+	{Key: "mcp.transport", EnvVar: "DIRSTRAL_MCP_TRANSPORT"},
+	{Key: "model", EnvVar: "DIRSTRAL_MODEL"},
+	{Key: "verbose", EnvVar: "DIRSTRAL_VERBOSE"},
+	{Key: "host.listen", EnvVar: "DIRSTRAL_HOST_LISTEN"},
+	{Key: "host.mcp_path", EnvVar: "DIRSTRAL_HOST_MCP_PATH"},
+	{Key: "elevenlabs.base_url", EnvVar: "ELEVENLABS_BASE_URL"},
+	{Key: "elevenlabs.voice", EnvVar: "DIRSTRAL_VOICE"},
+	{Key: "DIR2MCP_AUTH_TOKEN", EnvVar: "DIR2MCP_AUTH_TOKEN", Sensitive: true},
+	{Key: "ELEVENLABS_API_KEY", EnvVar: "ELEVENLABS_API_KEY", Sensitive: true},
+}
+
+// fieldValueFromConfig extracts a config field value by key name.
+func fieldValueFromConfig(cfg Config, key string) string {
+	switch key {
+	case "mcp.url":
+		return cfg.MCP.URL
+	case "mcp.transport":
+		return cfg.MCP.Transport
+	case "model":
+		return cfg.Model
+	case "verbose":
+		if cfg.Verbose {
+			return "true"
+		}
+		return "false"
+	case "host.listen":
+		return cfg.Host.Listen
+	case "host.mcp_path":
+		return cfg.Host.MCPPath
+	case "elevenlabs.base_url":
+		return cfg.ElevenLabs.BaseURL
+	case "elevenlabs.voice":
+		return cfg.ElevenLabs.Voice
+	default:
+		return ""
+	}
+}
+
+// readDotFile reads a dotenv file and returns its key-value pairs.
+// Returns nil map if the file does not exist.
+func readDotFile(name string) map[string]string {
+	vals, err := godotenv.Read(name)
+	if err != nil {
+		return nil
+	}
+	return vals
+}
+
+// EffectiveFields returns info about each configurable field including
+// which source provided its current value, checked in precedence order:
+// env var → .env.local → .env → config.toml → default.
+func EffectiveFields(cfg Config) []FieldInfo {
+	dotEnvLocal := readDotFile(".env.local")
+	dotEnv := readDotFile(".env")
+
+	// Load config.toml into a separate struct to check overrides.
+	fileCfg := Default()
+	_ = mergeUserConfig(&fileCfg)
+
+	def := Default()
+	result := make([]FieldInfo, 0, len(fieldDefs))
+
+	for _, fd := range fieldDefs {
+		fi := FieldInfo{
+			Key:       fd.Key,
+			Sensitive: fd.Sensitive,
+		}
+
+		// For secret-only fields, the value only comes from env / dotenv.
+		if fd.Sensitive {
+			fi.Value = os.Getenv(fd.EnvVar)
+			fi.Source = resolveSecretSource(fd.EnvVar, dotEnvLocal, dotEnv)
+			result = append(result, fi)
+			continue
+		}
+
+		// Check precedence: env → .env.local → .env → config.toml → default.
+		if v, ok := os.LookupEnv(fd.EnvVar); ok && strings.TrimSpace(v) != "" {
+			fi.Value = strings.TrimSpace(v)
+			// Disambiguate: was it set in shell env or loaded from dotenv?
+			if _, inLocal := dotEnvLocal[fd.EnvVar]; inLocal {
+				fi.Source = SourceDotEnvLocal
+			} else if _, inDot := dotEnv[fd.EnvVar]; inDot {
+				fi.Source = SourceDotEnv
+			} else {
+				fi.Source = SourceEnv
+			}
+			result = append(result, fi)
+			continue
+		}
+
+		// Check config.toml (compare against default to detect overrides).
+		fileVal := fieldValueFromConfig(fileCfg, fd.Key)
+		defVal := fieldValueFromConfig(def, fd.Key)
+		if fileVal != defVal {
+			fi.Value = fileVal
+			fi.Source = SourceConfigFile
+			result = append(result, fi)
+			continue
+		}
+
+		// Default value.
+		fi.Value = fieldValueFromConfig(cfg, fd.Key)
+		fi.Source = SourceDefault
+		result = append(result, fi)
+	}
+	return result
+}
+
+// resolveSecretSource determines the source for a secret env var.
+func resolveSecretSource(envVar string, dotEnvLocal, dotEnv map[string]string) FieldSource {
+	if _, ok := dotEnvLocal[envVar]; ok {
+		return SourceDotEnvLocal
+	}
+	if _, ok := dotEnv[envVar]; ok {
+		return SourceDotEnv
+	}
+	if _, ok := os.LookupEnv(envVar); ok {
+		return SourceEnv
+	}
+	return SourceDefault
+}
+
+// ValidateField checks whether value is valid for the given field key.
+func ValidateField(key, value string) error {
+	switch key {
+	case "mcp.url":
+		if strings.TrimSpace(value) == "" {
+			return errors.New("mcp.url must not be empty")
+		}
+	case "mcp.transport":
+		if value != "streamable-http" && value != "stdio" {
+			return fmt.Errorf("mcp.transport must be \"streamable-http\" or \"stdio\", got %q", value)
+		}
+	case "model":
+		if strings.TrimSpace(value) == "" {
+			return errors.New("model must not be empty")
+		}
+	case "verbose":
+		if value != "true" && value != "false" {
+			return fmt.Errorf("verbose must be \"true\" or \"false\", got %q", value)
+		}
+	case "host.listen":
+		if !strings.Contains(value, ":") {
+			return errors.New("host.listen must contain \":\" (e.g. \"127.0.0.1:8087\")")
+		}
+	case "host.mcp_path":
+		if !strings.HasPrefix(value, "/") {
+			return errors.New("host.mcp_path must start with \"/\"")
+		}
+	case "elevenlabs.base_url":
+		if strings.TrimSpace(value) == "" {
+			return errors.New("elevenlabs.base_url must not be empty")
+		}
+		if !strings.HasPrefix(value, "http") {
+			return errors.New("elevenlabs.base_url must start with \"http\"")
+		}
+	case "elevenlabs.voice":
+		if strings.TrimSpace(value) == "" {
+			return errors.New("elevenlabs.voice must not be empty")
+		}
+	}
+	return nil
+}
+
+// ApplyField sets a field on the config struct by key name.
+func ApplyField(cfg *Config, key, value string) {
+	switch key {
+	case "mcp.url":
+		cfg.MCP.URL = value
+	case "mcp.transport":
+		cfg.MCP.Transport = value
+	case "model":
+		cfg.Model = value
+	case "verbose":
+		cfg.Verbose = strings.EqualFold(value, "true") || value == "1"
+	case "host.listen":
+		cfg.Host.Listen = value
+	case "host.mcp_path":
+		cfg.Host.MCPPath = value
+	case "elevenlabs.base_url":
+		cfg.ElevenLabs.BaseURL = value
+	case "elevenlabs.voice":
+		cfg.ElevenLabs.Voice = value
+	}
+}
+
+// DefaultValueForField returns the default value for a field key.
+func DefaultValueForField(key string) string {
+	return fieldValueFromConfig(Default(), key)
 }

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -148,7 +148,6 @@ func Up(ctx context.Context, opts UpOptions) error {
 	}
 }
 
-// UpDetached starts dir2mcp as a managed background process and returns immediately.
 // LogPath returns the path to the lighthouse log file.
 func LogPath() string {
 	return filepath.Join(os.TempDir(), "dirstral-lighthouse.log")

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -149,6 +149,12 @@ func Up(ctx context.Context, opts UpOptions) error {
 }
 
 // UpDetached starts dir2mcp as a managed background process and returns immediately.
+// LogPath returns the path to the lighthouse log file.
+func LogPath() string {
+	return filepath.Join(os.TempDir(), "dirstral-lighthouse.log")
+}
+
+// UpDetached starts dir2mcp as a managed background process and returns immediately.
 func UpDetached(ctx context.Context, opts UpOptions) error {
 	baseCommand, baseArgs, workDir, err := resolveDir2MCPCommand()
 	if err != nil {
@@ -183,7 +189,7 @@ func UpDetached(ctx context.Context, opts UpOptions) error {
 		cmd.Dir = workDir
 	}
 
-	logFile, err := os.OpenFile(filepath.Join(os.TempDir(), "dirstral-lighthouse.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	logFile, err := os.OpenFile(LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -33,6 +33,7 @@ type model struct {
 	statusMsg string
 	width     int
 	height    int
+	showHelp  bool
 }
 
 func initialModel(cfg config.Config) model {
@@ -67,8 +68,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.input.Width = maxInt(settingsContentWidth(msg.Width)-4, 20)
 		return m, nil
 	case tea.KeyMsg:
+		if msg.String() == "?" || msg.String() == "ctrl+k" {
+			m.showHelp = !m.showHelp
+			return m, nil
+		}
+		if m.showHelp {
+			switch msg.String() {
+			case "esc", "q", "?", "ctrl+k":
+				m.showHelp = false
+			}
+			return m, nil
+		}
 		return m.handleKey(msg)
 	}
 
@@ -257,40 +270,217 @@ func (m model) handleConfirmQuitKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// ── View ──────────────────────────────────────────────────────────────
-
 var (
-	headerStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(ui.ClrBrand).
-			MarginBottom(1)
+	settingsTitleStyle = lipgloss.NewStyle().
+				Foreground(ui.ClrBrand).
+				Bold(true).
+				Underline(true)
 
-	selectedStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(ui.ClrBrand)
+	settingsMutedStyle = lipgloss.NewStyle().
+				Foreground(ui.ClrMuted)
 
-	sourceStyle = lipgloss.NewStyle().
-			Foreground(ui.ClrMuted).
-			Italic(true)
+	settingsSubtleStyle = lipgloss.NewStyle().
+				Foreground(ui.ClrSubtle)
 
-	footerStyle = lipgloss.NewStyle().
-			Foreground(ui.ClrMuted).
-			MarginTop(1)
+	settingsPanelStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(ui.ClrSubtle).
+				Padding(1, 2).
+				MarginTop(1).
+				MarginBottom(1)
+
+	settingsSelectedMarkerStyle = lipgloss.NewStyle().
+					Foreground(ui.ClrBrand).
+					Bold(true)
+
+	settingsSelectedKeyStyle = lipgloss.NewStyle().
+					Background(ui.ClrBrand).
+					Foreground(lipgloss.Color("0")).
+					Bold(true)
+
+	settingsKeyStyle = lipgloss.NewStyle().
+				Foreground(ui.ClrMuted)
+
+	settingsValueStyle = lipgloss.NewStyle().
+				Foreground(ui.ClrSubtle)
+
+	settingsSelectedValueStyle = lipgloss.NewStyle().
+					Foreground(ui.ClrBrand).
+					Italic(true)
+
+	settingsSourceStyle = lipgloss.NewStyle().
+				Foreground(ui.ClrMuted).
+				Italic(true)
 )
 
 func (m model) View() string {
-	var b strings.Builder
+	viewWidth := m.width
+	if viewWidth <= 0 {
+		viewWidth = 100
+	}
 
-	b.WriteString(headerStyle.Render("⚙  Settings"))
-	b.WriteString("\n")
+	tinyHeight := m.height > 0 && m.height < 14
+	contentWidth := settingsContentWidth(viewWidth)
+	panelWidth := settingsPanelWidth(viewWidth, contentWidth)
 
-	// Visible rows (leave room for header, footer, status).
-	maxRows := m.height - 8
+	title := settingsTitleStyle.MaxWidth(contentWidth).Render("Settings")
+	intro := settingsMutedStyle.MaxWidth(contentWidth).Render("Edit config and API defaults for Dirstral.")
+	header := joinVerticalNonEmpty(
+		lipgloss.Center,
+		lipgloss.PlaceHorizontal(panelWidth, lipgloss.Center, title),
+		lipgloss.PlaceHorizontal(panelWidth, lipgloss.Center, intro),
+	)
+
+	panelLines := m.fieldRows(contentWidth)
+	stateLines := m.stateLines()
+	if len(stateLines) > 0 {
+		panelLines = append(panelLines, "")
+		panelLines = append(panelLines, stateLines...)
+	}
+	panel := settingsPanelStyle.MaxWidth(panelWidth).Render(strings.Join(panelLines, "\n"))
+
+	body := joinVerticalNonEmpty(lipgloss.Center, header, panel)
+	if m.showHelp {
+		help := settingsPanelStyle.MaxWidth(panelWidth).Render(settingsHelpText(contentWidth, tinyHeight))
+		body = joinVerticalNonEmpty(lipgloss.Center, body, help)
+	}
+
+	footer := settingsSubtleStyle.MaxWidth(contentWidth).Render(truncateText(m.controlsHint(), contentWidth))
+	content := composeWithPinnedFooter(body, footer, m.height)
+
+	if m.height <= 0 {
+		return content
+	}
+	vAlign := lipgloss.Center
+	if tinyHeight {
+		vAlign = lipgloss.Top
+	}
+	return lipgloss.Place(viewWidth, m.height, lipgloss.Center, vAlign, content)
+}
+
+func (m model) fieldRows(contentWidth int) []string {
+	maxRows := m.visibleRows()
+	start, end := m.visibleRange(maxRows)
+
+	keyWidth := clampInt(contentWidth/3, 18, 30)
+	sourceWidth := clampInt(contentWidth/6, 10, 18)
+	valueWidth := maxInt(contentWidth-keyWidth-sourceWidth-10, 12)
+
+	lines := make([]string, 0, end-start+2)
+	for i := start; i < end; i++ {
+		f := m.fields[i]
+		marker := settingsSubtleStyle.Render(" ")
+
+		keyText := fitText(f.Key, keyWidth)
+		valueText := fitText(fieldDisplayValue(f), valueWidth)
+		sourceText := fitText("("+string(f.Source)+")", sourceWidth)
+
+		keyCell := settingsKeyStyle.Width(keyWidth).Render(keyText)
+		valueCell := settingsValueStyle.Width(valueWidth).Render(valueText)
+		if i == m.cursor {
+			marker = settingsSelectedMarkerStyle.Render(">")
+			keyCell = settingsSelectedKeyStyle.Width(keyWidth).Render(keyText)
+			valueCell = settingsSelectedValueStyle.Width(valueWidth).Render(valueText)
+		}
+		sourceCell := settingsSourceStyle.Width(sourceWidth).Render(sourceText)
+		lines = append(lines, fmt.Sprintf("  %s %s  %s  %s", marker, keyCell, valueCell, sourceCell))
+	}
+
+	if len(lines) == 0 {
+		lines = append(lines, settingsSubtleStyle.Render("  (no settings fields)"))
+	}
+
+	if len(m.fields) > maxRows {
+		lines = append(lines, "")
+		lines = append(lines, settingsSubtleStyle.Render(fmt.Sprintf("  [%d/%d]", m.cursor+1, len(m.fields))))
+	}
+
+	return lines
+}
+
+func (m model) stateLines() []string {
+	lines := make([]string, 0, 4)
+
+	switch m.state {
+	case stateEditing:
+		lines = append(lines, settingsMutedStyle.Render("Editing "+m.fields[m.cursor].Key))
+		lines = append(lines, "  "+m.input.View())
+		if m.errMsg != "" {
+			lines = append(lines, ui.Red.Render("  "+m.errMsg))
+		}
+	case stateConfirmQuit:
+		lines = append(lines, ui.Yellow.Render("Unsaved changes. Save before quitting?"))
+		if m.errMsg != "" {
+			lines = append(lines, ui.Red.Render(m.errMsg))
+		}
+	default:
+		if m.errMsg != "" {
+			lines = append(lines, ui.Red.Render(m.errMsg))
+		}
+		if m.statusMsg != "" {
+			lines = append(lines, ui.Green.Render(m.statusMsg))
+		}
+		if m.dirty {
+			lines = append(lines, ui.Yellow.Render("Unsaved changes"))
+		}
+	}
+
+	return lines
+}
+
+func settingsHelpText(contentWidth int, tinyHeight bool) string {
+	if tinyHeight {
+		return settingsSubtleStyle.Render(truncateText("Keys: up/down or j/k move, enter edit, r reset, s save, esc/q back, ? toggle help", contentWidth))
+	}
+
+	lines := []string{
+		settingsTitleStyle.Render("Settings Keymap"),
+		settingsMutedStyle.Render("up/down or j/k  move selection"),
+		settingsMutedStyle.Render("enter           edit selected value"),
+		settingsMutedStyle.Render("r               reset selected value"),
+		settingsMutedStyle.Render("s               save changes"),
+		settingsMutedStyle.Render("esc/q           back/quit"),
+		settingsMutedStyle.Render("? or ctrl+k     toggle this help"),
+	}
+	return lipgloss.NewStyle().MaxWidth(maxInt(contentWidth-2, 12)).Render(strings.Join(lines, "\n"))
+}
+
+func (m model) controlsHint() string {
+	switch m.state {
+	case stateEditing:
+		return "type value · enter confirm · esc cancel · ? help"
+	case stateConfirmQuit:
+		return "y save & quit · n discard & quit · c/esc cancel · ? help"
+	default:
+		return "up/down or j/k move · enter edit · r reset · s save · esc/q back · ? help"
+	}
+}
+
+func fieldDisplayValue(f config.FieldInfo) string {
+	if f.Sensitive {
+		if strings.TrimSpace(f.Value) == "" {
+			return "(not set)"
+		}
+		return "****"
+	}
+	if strings.TrimSpace(f.Value) == "" {
+		return "(not set)"
+	}
+	return f.Value
+}
+
+func (m model) visibleRows() int {
+	maxRows := m.height - 12
+	if m.showHelp {
+		maxRows -= 4
+	}
 	if maxRows < 5 {
 		maxRows = 5
 	}
+	return maxRows
+}
 
-	// Scrolling window.
+func (m model) visibleRange(maxRows int) (int, int) {
 	start := 0
 	if m.cursor >= maxRows {
 		start = m.cursor - maxRows + 1
@@ -299,63 +489,110 @@ func (m model) View() string {
 	if end > len(m.fields) {
 		end = len(m.fields)
 	}
+	return start, end
+}
 
-	for i := start; i < end; i++ {
-		f := m.fields[i]
-		cursor := "  "
-		if i == m.cursor {
-			cursor = ui.Brand.Render("▸ ")
-		}
-
-		displayVal := f.Value
-		if f.Sensitive && f.Value != "" {
-			displayVal = "****"
-		}
-		if f.Value == "" {
-			displayVal = ui.Muted.Render("(not set)")
-		}
-
-		keyStr := f.Key
-		if i == m.cursor {
-			keyStr = selectedStyle.Render(f.Key)
-		}
-
-		src := sourceStyle.Render(fmt.Sprintf("(%s)", f.Source))
-
-		_, _ = fmt.Fprintf(&b, "%s%-25s %s %s\n", cursor, keyStr, displayVal, src)
+func settingsContentWidth(viewWidth int) int {
+	menuHorizChrome := 6
+	if viewWidth >= 56 {
+		menuHorizChrome = 10
 	}
+	return clampInt(viewWidth-menuHorizChrome, 28, 108)
+}
 
-	// Scroll indicator.
-	if len(m.fields) > maxRows {
-		b.WriteString(ui.Muted.Render(fmt.Sprintf("  [%d/%d]\n", m.cursor+1, len(m.fields))))
+func settingsPanelWidth(viewWidth, contentWidth int) int {
+	menuHorizChrome := 6
+	if viewWidth >= 56 {
+		menuHorizChrome = 10
 	}
+	return contentWidth + menuHorizChrome - 2
+}
 
-	b.WriteString("\n")
-
-	// State-specific footer.
-	switch m.state {
-	case stateEditing:
-		_, _ = fmt.Fprintf(&b, "  Editing %s:\n", ui.Brand.Render(m.fields[m.cursor].Key))
-		b.WriteString("  " + m.input.View() + "\n")
-		if m.errMsg != "" {
-			b.WriteString("  " + ui.Red.Render(m.errMsg) + "\n")
-		}
-		b.WriteString(footerStyle.Render("  enter: confirm  esc: cancel"))
-	case stateConfirmQuit:
-		b.WriteString(ui.Yellow.Render("  You have unsaved changes. Save before quitting?") + "\n")
-		if m.errMsg != "" {
-			b.WriteString("  " + ui.Red.Render(m.errMsg) + "\n")
-		}
-		b.WriteString(footerStyle.Render("  y: save & quit  n: discard & quit  c/esc: cancel"))
-	default:
-		if m.errMsg != "" {
-			b.WriteString("  " + ui.Red.Render(m.errMsg) + "\n")
-		}
-		if m.statusMsg != "" {
-			b.WriteString("  " + ui.Green.Render(m.statusMsg) + "\n")
-		}
-		b.WriteString(footerStyle.Render("  ↑/↓: navigate  enter: edit  r: reset  s: save  q: quit"))
+func composeWithPinnedFooter(body, footer string, height int) string {
+	if height <= 0 {
+		return joinVerticalNonEmpty(lipgloss.Left, body, footer)
 	}
+	bodyLines := splitLines(body)
+	footerLines := splitLines(footer)
+	if len(footerLines) >= height {
+		return strings.Join(footerLines[:height], "\n")
+	}
+	bodyBudget := height - len(footerLines)
+	if bodyBudget < len(bodyLines) {
+		if bodyBudget <= 0 {
+			bodyLines = nil
+		} else {
+			bodyLines = bodyLines[:bodyBudget]
+		}
+	}
+	lines := make([]string, 0, len(bodyLines)+len(footerLines))
+	lines = append(lines, bodyLines...)
+	lines = append(lines, footerLines...)
+	return strings.Join(lines, "\n")
+}
 
-	return b.String()
+func joinVerticalNonEmpty(pos lipgloss.Position, items ...string) string {
+	nonEmpty := make([]string, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(item) == "" {
+			continue
+		}
+		nonEmpty = append(nonEmpty, item)
+	}
+	if len(nonEmpty) == 0 {
+		return ""
+	}
+	return lipgloss.JoinVertical(pos, nonEmpty...)
+}
+
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}
+
+func truncateText(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	r := []rune(strings.TrimSpace(s))
+	if len(r) <= width {
+		return string(r)
+	}
+	if width <= 3 {
+		return string(r[:width])
+	}
+	return string(r[:width-3]) + "..."
+}
+
+func fitText(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	r := []rune(strings.TrimSpace(s))
+	if len(r) <= width {
+		return string(r) + strings.Repeat(" ", width-len(r))
+	}
+	if width <= 3 {
+		return string(r[:width])
+	}
+	return string(r[:width-3]) + "..."
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func clampInt(v, minV, maxV int) int {
+	if v < minV {
+		return minV
+	}
+	if v > maxV {
+		return maxV
+	}
+	return v
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -220,7 +220,11 @@ func (m *model) save() {
 	// Save secrets to .env.local.
 	for _, f := range m.fields {
 		if f.Sensitive && f.Value != "" {
-			if err := config.SaveSecret(f.Key, f.Value); err != nil {
+			envKey := config.EnvVarForField(f.Key)
+			if envKey == "" {
+				envKey = f.Key
+			}
+			if err := config.SaveSecret(envKey, f.Value); err != nil {
 				m.errMsg = fmt.Sprintf("Save secret %s failed: %v", f.Key, err)
 				return
 			}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,0 +1,357 @@
+// Package settings provides an interactive TUI for editing dirstral configuration.
+package settings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alibilge/dirstral-cli/internal/config"
+	"github.com/alibilge/dirstral-cli/internal/ui"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// viewState tracks the current interaction mode.
+type viewState int
+
+const (
+	stateBrowsing viewState = iota
+	stateEditing
+	stateConfirmQuit
+)
+
+// model is the bubbletea model for the settings editor.
+type model struct {
+	cfg       config.Config
+	fields    []config.FieldInfo
+	cursor    int
+	state     viewState
+	input     textinput.Model
+	dirty     bool
+	errMsg    string
+	statusMsg string
+	width     int
+	height    int
+}
+
+func initialModel(cfg config.Config) model {
+	ti := textinput.New()
+	ti.CharLimit = 256
+	ti.Width = 60
+
+	fields := config.EffectiveFields(cfg)
+
+	return model{
+		cfg:    cfg,
+		fields: fields,
+		cursor: 0,
+		state:  stateBrowsing,
+		input:  ti,
+	}
+}
+
+// Run launches the settings TUI as its own tea.Program.
+func Run(cfg config.Config) error {
+	p := tea.NewProgram(initialModel(cfg), tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}
+
+func (m model) Init() tea.Cmd {
+	return nil
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+
+	// Forward to text input when editing.
+	if m.state == stateEditing {
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.state {
+	case stateBrowsing:
+		return m.handleBrowsingKey(msg)
+	case stateEditing:
+		return m.handleEditingKey(msg)
+	case stateConfirmQuit:
+		return m.handleConfirmQuitKey(msg)
+	}
+	return m, nil
+}
+
+func (m model) handleBrowsingKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		if m.dirty {
+			m.state = stateConfirmQuit
+			m.errMsg = ""
+			m.statusMsg = ""
+			return m, nil
+		}
+		return m, tea.Quit
+	case "ctrl+c":
+		return m, tea.Quit
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		m.errMsg = ""
+	case "down", "j":
+		if m.cursor < len(m.fields)-1 {
+			m.cursor++
+		}
+		m.errMsg = ""
+	case "enter":
+		m.startEditing()
+		return m, m.input.Focus()
+	case "r":
+		m.resetField()
+	case "s":
+		m.save()
+	}
+	return m, nil
+}
+
+func (m *model) startEditing() {
+	f := m.fields[m.cursor]
+	m.state = stateEditing
+	m.errMsg = ""
+	m.statusMsg = ""
+	m.input.SetValue(f.Value)
+	m.input.CursorEnd()
+	if f.Sensitive {
+		m.input.EchoMode = textinput.EchoPassword
+	} else {
+		m.input.EchoMode = textinput.EchoNormal
+	}
+	m.input.Placeholder = fmt.Sprintf("Enter value for %s", f.Key)
+}
+
+func (m model) handleEditingKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.state = stateBrowsing
+		m.errMsg = ""
+		m.input.Blur()
+		return m, nil
+	case "enter":
+		return m.commitEdit()
+	}
+
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	// Live validation feedback.
+	val := m.input.Value()
+	if err := config.ValidateField(m.fields[m.cursor].Key, val); err != nil {
+		m.errMsg = err.Error()
+	} else {
+		m.errMsg = ""
+	}
+	return m, cmd
+}
+
+func (m model) commitEdit() (tea.Model, tea.Cmd) {
+	key := m.fields[m.cursor].Key
+	val := m.input.Value()
+
+	if err := config.ValidateField(key, val); err != nil {
+		m.errMsg = err.Error()
+		return m, nil
+	}
+
+	// Apply to the in-memory config or track secret change.
+	if m.fields[m.cursor].Sensitive {
+		m.fields[m.cursor].Value = val
+		m.fields[m.cursor].Source = config.SourceDotEnvLocal
+	} else {
+		config.ApplyField(&m.cfg, key, val)
+		m.fields[m.cursor].Value = val
+		m.fields[m.cursor].Source = config.SourceConfigFile
+	}
+
+	m.dirty = true
+	m.state = stateBrowsing
+	m.errMsg = ""
+	m.statusMsg = fmt.Sprintf("Updated %s", key)
+	m.input.Blur()
+	return m, nil
+}
+
+func (m *model) resetField() {
+	f := &m.fields[m.cursor]
+	def := config.DefaultValueForField(f.Key)
+	if def == "" && f.Sensitive {
+		m.errMsg = "No default for secrets"
+		return
+	}
+	if def == "" {
+		m.errMsg = "No default value for this field"
+		return
+	}
+	config.ApplyField(&m.cfg, f.Key, def)
+	f.Value = def
+	f.Source = config.SourceDefault
+	m.dirty = true
+	m.errMsg = ""
+	m.statusMsg = fmt.Sprintf("Reset %s to default", f.Key)
+}
+
+func (m *model) save() {
+	// Save non-sensitive fields to config.toml.
+	if err := config.Save(m.cfg); err != nil {
+		m.errMsg = fmt.Sprintf("Save failed: %v", err)
+		return
+	}
+
+	// Save secrets to .env.local.
+	for _, f := range m.fields {
+		if f.Sensitive && f.Value != "" {
+			if err := config.SaveSecret(f.Key, f.Value); err != nil {
+				m.errMsg = fmt.Sprintf("Save secret %s failed: %v", f.Key, err)
+				return
+			}
+		}
+	}
+
+	m.dirty = false
+	m.errMsg = ""
+	m.statusMsg = "Settings saved"
+}
+
+func (m model) handleConfirmQuitKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y":
+		m.save()
+		if m.errMsg != "" {
+			// Save failed, stay in confirm state.
+			return m, nil
+		}
+		return m, tea.Quit
+	case "n", "N":
+		return m, tea.Quit
+	case "esc", "c":
+		m.state = stateBrowsing
+		m.statusMsg = ""
+		return m, nil
+	case "ctrl+c":
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+// ── View ──────────────────────────────────────────────────────────────
+
+var (
+	headerStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(ui.ClrBrand).
+			MarginBottom(1)
+
+	selectedStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(ui.ClrBrand)
+
+	sourceStyle = lipgloss.NewStyle().
+			Foreground(ui.ClrMuted).
+			Italic(true)
+
+	footerStyle = lipgloss.NewStyle().
+			Foreground(ui.ClrMuted).
+			MarginTop(1)
+)
+
+func (m model) View() string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Render("⚙  Settings"))
+	b.WriteString("\n")
+
+	// Visible rows (leave room for header, footer, status).
+	maxRows := m.height - 8
+	if maxRows < 5 {
+		maxRows = 5
+	}
+
+	// Scrolling window.
+	start := 0
+	if m.cursor >= maxRows {
+		start = m.cursor - maxRows + 1
+	}
+	end := start + maxRows
+	if end > len(m.fields) {
+		end = len(m.fields)
+	}
+
+	for i := start; i < end; i++ {
+		f := m.fields[i]
+		cursor := "  "
+		if i == m.cursor {
+			cursor = ui.Brand.Render("▸ ")
+		}
+
+		displayVal := f.Value
+		if f.Sensitive && f.Value != "" {
+			displayVal = "****"
+		}
+		if f.Value == "" {
+			displayVal = ui.Muted.Render("(not set)")
+		}
+
+		keyStr := f.Key
+		if i == m.cursor {
+			keyStr = selectedStyle.Render(f.Key)
+		}
+
+		src := sourceStyle.Render(fmt.Sprintf("(%s)", f.Source))
+
+		b.WriteString(fmt.Sprintf("%s%-25s %s %s\n", cursor, keyStr, displayVal, src))
+	}
+
+	// Scroll indicator.
+	if len(m.fields) > maxRows {
+		b.WriteString(ui.Muted.Render(fmt.Sprintf("  [%d/%d]\n", m.cursor+1, len(m.fields))))
+	}
+
+	b.WriteString("\n")
+
+	// State-specific footer.
+	switch m.state {
+	case stateEditing:
+		b.WriteString(fmt.Sprintf("  Editing %s:\n", ui.Brand.Render(m.fields[m.cursor].Key)))
+		b.WriteString("  " + m.input.View() + "\n")
+		if m.errMsg != "" {
+			b.WriteString("  " + ui.Red.Render(m.errMsg) + "\n")
+		}
+		b.WriteString(footerStyle.Render("  enter: confirm  esc: cancel"))
+	case stateConfirmQuit:
+		b.WriteString(ui.Yellow.Render("  You have unsaved changes. Save before quitting?") + "\n")
+		if m.errMsg != "" {
+			b.WriteString("  " + ui.Red.Render(m.errMsg) + "\n")
+		}
+		b.WriteString(footerStyle.Render("  y: save & quit  n: discard & quit  c/esc: cancel"))
+	default:
+		if m.errMsg != "" {
+			b.WriteString("  " + ui.Red.Render(m.errMsg) + "\n")
+		}
+		if m.statusMsg != "" {
+			b.WriteString("  " + ui.Green.Render(m.statusMsg) + "\n")
+		}
+		b.WriteString(footerStyle.Render("  ↑/↓: navigate  enter: edit  r: reset  s: save  q: quit"))
+	}
+
+	return b.String()
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -318,7 +318,7 @@ func (m model) View() string {
 
 		src := sourceStyle.Render(fmt.Sprintf("(%s)", f.Source))
 
-		b.WriteString(fmt.Sprintf("%s%-25s %s %s\n", cursor, keyStr, displayVal, src))
+		_, _ = fmt.Fprintf(&b, "%s%-25s %s %s\n", cursor, keyStr, displayVal, src)
 	}
 
 	// Scroll indicator.
@@ -331,7 +331,7 @@ func (m model) View() string {
 	// State-specific footer.
 	switch m.state {
 	case stateEditing:
-		b.WriteString(fmt.Sprintf("  Editing %s:\n", ui.Brand.Render(m.fields[m.cursor].Key)))
+		_, _ = fmt.Fprintf(&b, "  Editing %s:\n", ui.Brand.Render(m.fields[m.cursor].Key))
 		b.WriteString("  " + m.input.View() + "\n")
 		if m.errMsg != "" {
 			b.WriteString("  " + ui.Red.Render(m.errMsg) + "\n")

--- a/internal/settings/settings_ui_test.go
+++ b/internal/settings/settings_ui_test.go
@@ -1,0 +1,71 @@
+package settings
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alibilge/dirstral-cli/internal/config"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestSettingsViewUsesMenuLikeChrome(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	m := initialModel(config.Default())
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 28})
+	view := updated.(model).View()
+
+	if !strings.Contains(view, "Settings") {
+		t.Fatalf("expected settings title in view")
+	}
+	if !strings.Contains(view, "Edit config and API defaults for Dirstral.") {
+		t.Fatalf("expected menu-style intro in view")
+	}
+	if !strings.Contains(view, "╭") || !strings.Contains(view, "╯") {
+		t.Fatalf("expected bordered panel chrome in view")
+	}
+	if !strings.Contains(view, "? help") {
+		t.Fatalf("expected controls footer to include help hint")
+	}
+}
+
+func TestSettingsHelpOverlayToggle(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	m := initialModel(config.Default())
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 28})
+	m = updated.(model)
+
+	if strings.Contains(m.View(), "Settings Keymap") {
+		t.Fatalf("expected help overlay hidden by default")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	withHelp := updated.(model)
+	if !strings.Contains(withHelp.View(), "Settings Keymap") {
+		t.Fatalf("expected help overlay visible after ?")
+	}
+
+	updated, cmd := withHelp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd != nil {
+		t.Fatalf("expected q to close help overlay without quitting")
+	}
+	withoutHelp := updated.(model)
+	if strings.Contains(withoutHelp.View(), "Settings Keymap") {
+		t.Fatalf("expected help overlay hidden after q")
+	}
+}
+
+func TestSettingsControlsReflectEditingState(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	m := initialModel(config.Default())
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	m = updated.(model)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	editing := updated.(model)
+	if !strings.Contains(editing.View(), "enter confirm") {
+		t.Fatalf("expected editing controls hint")
+	}
+}

--- a/tests/lighthouse_logs_test.go
+++ b/tests/lighthouse_logs_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alibilge/dirstral-cli/internal/app"
+	"github.com/alibilge/dirstral-cli/internal/host"
+)
+
+func TestTailLogLinesKeepsLastN(t *testing.T) {
+	raw := "line1\nline2\nline3\nline4\n"
+	got := app.TailLogLines(raw, 2)
+	want := "line3\nline4"
+	if got != want {
+		t.Fatalf("unexpected tailed logs: got %q want %q", got, want)
+	}
+}
+
+func TestTailLogLinesHandlesEmptyAndUnlimited(t *testing.T) {
+	if got := app.TailLogLines("\n", 100); got != "" {
+		t.Fatalf("expected empty output for blank input, got %q", got)
+	}
+
+	raw := "a\nb\nc"
+	if got := app.TailLogLines(raw, 0); got != raw {
+		t.Fatalf("expected maxLines=0 to keep all lines, got %q", got)
+	}
+}
+
+func TestHostLogPathUsesTempDir(t *testing.T) {
+	got := host.LogPath()
+	want := filepath.Join(os.TempDir(), "dirstral-lighthouse.log")
+	if got != want {
+		t.Fatalf("unexpected log path: got %q want %q", got, want)
+	}
+}

--- a/tests/lighthouse_menu_test.go
+++ b/tests/lighthouse_menu_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLighthouseMenuItemsOrder(t *testing.T) {
-	want := []string{"Start Server", "Server Status", "Stop Server", "Back"}
+	want := []string{"Start Server", "Server Status", "View Logs", "Stop Server", "Back"}
 	if got := app.LighthouseMenuItems(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected lighthouse options: got %v want %v", got, want)
 	}

--- a/tests/menu_test.go
+++ b/tests/menu_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestStartMenuItemsOrder(t *testing.T) {
-	want := []string{"Breeze", "Tempest", "Lighthouse", "Exit"}
+	want := []string{"Breeze", "Tempest", "Lighthouse", "Settings", "Exit"}
 	if got := app.StartMenuItems(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected startup menu options: got %v want %v", got, want)
 	}

--- a/tests/settings_test.go
+++ b/tests/settings_test.go
@@ -1,0 +1,207 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alibilge/dirstral-cli/internal/config"
+	"github.com/joho/godotenv"
+)
+
+type envState struct {
+	value string
+	ok    bool
+}
+
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir temp: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+	return dir
+}
+
+func unsetEnv(t *testing.T, keys ...string) {
+	t.Helper()
+	before := make(map[string]envState, len(keys))
+	for _, key := range keys {
+		v, ok := os.LookupEnv(key)
+		before[key] = envState{value: v, ok: ok}
+		_ = os.Unsetenv(key)
+	}
+	t.Cleanup(func() {
+		for _, key := range keys {
+			st := before[key]
+			if st.ok {
+				_ = os.Setenv(key, st.value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		}
+	})
+}
+
+func findField(t *testing.T, fields []config.FieldInfo, key string) config.FieldInfo {
+	t.Helper()
+	for _, field := range fields {
+		if field.Key == key {
+			return field
+		}
+	}
+	t.Fatalf("missing field %q", key)
+	return config.FieldInfo{}
+}
+
+func TestConfigSaveAndLoadRoundTrip(t *testing.T) {
+	chdirTemp(t)
+	unsetEnv(t,
+		"DIRSTRAL_MCP_URL",
+		"DIRSTRAL_MCP_TRANSPORT",
+		"DIRSTRAL_MODEL",
+		"DIRSTRAL_VERBOSE",
+		"DIRSTRAL_HOST_LISTEN",
+		"DIRSTRAL_HOST_MCP_PATH",
+		"ELEVENLABS_BASE_URL",
+		"DIRSTRAL_VOICE",
+	)
+
+	home := filepath.Join(t.TempDir(), "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	t.Setenv("HOME", home)
+
+	cfg := config.Default()
+	cfg.Model = "mistral-large-latest"
+	cfg.Host.MCPPath = "/custom-mcp"
+
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.Model != cfg.Model {
+		t.Fatalf("model mismatch: got %q want %q", loaded.Model, cfg.Model)
+	}
+	if loaded.Host.MCPPath != cfg.Host.MCPPath {
+		t.Fatalf("mcp_path mismatch: got %q want %q", loaded.Host.MCPPath, cfg.Host.MCPPath)
+	}
+}
+
+func TestSaveSecretWritesDotEnvLocalAndEnvironment(t *testing.T) {
+	chdirTemp(t)
+	unsetEnv(t, "ELEVENLABS_API_KEY")
+
+	if err := config.SaveSecret("ELEVENLABS_API_KEY", "test-secret"); err != nil {
+		t.Fatalf("save secret: %v", err)
+	}
+
+	envLocal, err := godotenv.Read(".env.local")
+	if err != nil {
+		t.Fatalf("read .env.local: %v", err)
+	}
+	if got := envLocal["ELEVENLABS_API_KEY"]; got != "test-secret" {
+		t.Fatalf(".env.local missing secret entry: got %q", got)
+	}
+	if got := os.Getenv("ELEVENLABS_API_KEY"); got != "test-secret" {
+		t.Fatalf("env not updated: got %q", got)
+	}
+}
+
+func TestEffectiveFieldsDetectConfigAndDefaultSources(t *testing.T) {
+	chdirTemp(t)
+	unsetEnv(t,
+		"DIRSTRAL_MODEL",
+		"DIRSTRAL_MCP_TRANSPORT",
+		"DIR2MCP_AUTH_TOKEN",
+		"ELEVENLABS_API_KEY",
+	)
+
+	home := filepath.Join(t.TempDir(), "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	t.Setenv("HOME", home)
+
+	cfg := config.Default()
+	cfg.Model = "from-config-file"
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	fields := config.EffectiveFields(loaded)
+	model := findField(t, fields, "model")
+	if model.Value != "from-config-file" {
+		t.Fatalf("unexpected model value: got %q", model.Value)
+	}
+	if model.Source != config.SourceConfigFile {
+		t.Fatalf("unexpected model source: got %q", model.Source)
+	}
+
+	transport := findField(t, fields, "mcp.transport")
+	if transport.Source != config.SourceDefault {
+		t.Fatalf("unexpected transport source: got %q", transport.Source)
+	}
+}
+
+func TestEffectiveFieldsDetectDotEnvLocalForNormalAndSecretFields(t *testing.T) {
+	chdirTemp(t)
+	unsetEnv(t, "DIRSTRAL_MODEL", "DIR2MCP_AUTH_TOKEN", "ELEVENLABS_API_KEY")
+
+	if err := os.WriteFile(".env.local", []byte("DIRSTRAL_MODEL=dotenv-model\nDIR2MCP_AUTH_TOKEN=token-from-local\n"), 0o644); err != nil {
+		t.Fatalf("write .env.local: %v", err)
+	}
+	if err := os.Setenv("DIRSTRAL_MODEL", "dotenv-model"); err != nil {
+		t.Fatalf("set model env: %v", err)
+	}
+	if err := os.Setenv("DIR2MCP_AUTH_TOKEN", "token-from-local"); err != nil {
+		t.Fatalf("set token env: %v", err)
+	}
+
+	fields := config.EffectiveFields(config.Default())
+	model := findField(t, fields, "model")
+	if model.Source != config.SourceDotEnvLocal {
+		t.Fatalf("unexpected model source: got %q", model.Source)
+	}
+
+	secret := findField(t, fields, "DIR2MCP_AUTH_TOKEN")
+	if secret.Source != config.SourceDotEnvLocal {
+		t.Fatalf("unexpected token source: got %q", secret.Source)
+	}
+	if secret.Value != "token-from-local" {
+		t.Fatalf("unexpected token value: got %q", secret.Value)
+	}
+}
+
+func TestValidateApplyAndDefaultHelpers(t *testing.T) {
+	if err := config.ValidateField("mcp.transport", "invalid"); err == nil {
+		t.Fatalf("expected validation error for invalid transport")
+	}
+
+	cfg := config.Default()
+	config.ApplyField(&cfg, "verbose", "true")
+	if !cfg.Verbose {
+		t.Fatalf("expected verbose=true after apply")
+	}
+
+	if got := config.DefaultValueForField("mcp.url"); got != config.Default().MCP.URL {
+		t.Fatalf("unexpected default mcp.url: got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a full in-CLI Settings editor (Bubble Tea) with field-level validation, source visibility, masking for sensitive values, reset-to-default, and save flows to `config.toml` and `.env.local`
- integrate Settings into the start menu and root mode loop, with post-exit config reload so updates immediately apply to Breeze/Tempest/Lighthouse defaults
- add Lighthouse log viewing UX: new `View Logs` action, log tail viewer TUI, host log-path helper, and dynamic home menu entry when Lighthouse is active
- extend tests for updated menu ordering plus new settings and lighthouse log utility coverage

## Verification
- `go vet ./...`
- `go test ./...`

Closes #29
Closes #16
Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "View Logs" in Lighthouse menu: interactive tailing viewer for real-time logs.
  * "Settings" in main menu: interactive TUI to edit, validate, persist configuration and secrets, and reload config.
  * Centralized log path helper for consistent log file location.

* **Tests**
  * Added tests for log tailing, menu ordering, and extensive configuration save/load, secrets, and field-provenance handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->