### PR TITLE
feat: show per-field unsaved changes in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,2 @@
 # Build artifacts
 /bin/
-/dirstral
-
-# Keep source entrypoint paths visible to git.
-!/cmd/
-!/cmd/dirstral/
-!/cmd/dirstral/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
-bin/
-dirstral
+# Build artifacts
+/bin/
+/dirstral
+
+# Keep source entrypoint paths visible to git.
+!/cmd/
+!/cmd/dirstral/
+!/cmd/dirstral/**

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ make build
 make run
 ```
 
+Build artifact notes:
+
+- `make build` writes the binary to `bin/dirstral`.
+- `make run` uses `go run ./cmd/dirstral` and does not create a root `./dirstral` file.
+- Avoid `go build -o dirstral ./cmd/dirstral` unless you intentionally want a local root binary.
+
 Install globally so you can run `dirstral` directly:
 
 ```bash

--- a/cmd/dirstral/main.go
+++ b/cmd/dirstral/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alibilge/dirstral-cli/internal/app"
+)
+
+func main() {
+	if err := app.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,6 +204,24 @@ func SaveSecret(key, value string) error {
 	return os.Setenv(key, value)
 }
 
+// DeleteSecret removes a key from .env.local and unsets it in the process env.
+func DeleteSecret(key string) error {
+	const path = ".env.local"
+	env := map[string]string{}
+	existing, err := godotenv.Read(path)
+	if err == nil {
+		env = existing
+	}
+	delete(env, key)
+	if err := godotenv.Write(env, path); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	if err := os.Unsetenv(key); err != nil {
+		return fmt.Errorf("unsetting %s: %w", key, err)
+	}
+	return nil
+}
+
 // fieldDef describes a configurable field for EffectiveFields.
 type fieldDef struct {
 	Key       string

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -23,18 +23,20 @@ const (
 
 // model is the bubbletea model for the settings editor.
 type model struct {
-	cfg       config.Config
-	fields    []config.FieldInfo
-	baseline  map[string]string
-	cursor    int
-	state     viewState
-	input     textinput.Model
-	dirty     bool
-	errMsg    string
-	statusMsg string
-	width     int
-	height    int
-	showHelp  bool
+	cfg                  config.Config
+	fields               []config.FieldInfo
+	baseline             map[string]string
+	cachedPendingChanges []pendingChange
+	pendingChangesValid  bool
+	cursor               int
+	state                viewState
+	input                textinput.Model
+	dirty                bool
+	errMsg               string
+	statusMsg            string
+	width                int
+	height               int
+	showHelp             bool
 }
 
 func initialModel(cfg config.Config) model {
@@ -205,6 +207,7 @@ func (m model) commitEdit() (tea.Model, tea.Cmd) {
 			config.ApplyField(&m.cfg, key, val)
 			m.fields[m.cursor].Value = val
 		}
+		m.invalidatePendingChanges()
 	}
 
 	m.recomputeDirty()
@@ -233,6 +236,7 @@ func (m *model) resetField() {
 	config.ApplyField(&m.cfg, f.Key, def)
 	f.Value = def
 	f.Source = config.SourceDefault
+	m.invalidatePendingChanges()
 	m.recomputeDirty()
 	m.errMsg = ""
 	m.statusMsg = fmt.Sprintf("Reset %s to default", f.Key)
@@ -269,6 +273,7 @@ func (m *model) save() {
 	m.applyPersistedSources()
 
 	m.baseline = snapshotValues(m.fields)
+	m.invalidatePendingChanges()
 	m.recomputeDirty()
 	m.errMsg = ""
 	m.statusMsg = "Settings saved"
@@ -302,6 +307,11 @@ type pendingChange struct {
 	sensitive bool
 }
 
+func (m *model) invalidatePendingChanges() {
+	m.cachedPendingChanges = nil
+	m.pendingChangesValid = false
+}
+
 func (m *model) recomputeDirty() {
 	m.dirty = len(m.pendingChanges()) > 0
 }
@@ -324,7 +334,10 @@ func (m *model) applyPersistedSources() {
 	}
 }
 
-func (m model) pendingChanges() []pendingChange {
+func (m *model) pendingChanges() []pendingChange {
+	if m.pendingChangesValid {
+		return m.cachedPendingChanges
+	}
 	changes := make([]pendingChange, 0)
 	for _, field := range m.fields {
 		before := m.baseline[field.Key]
@@ -338,10 +351,12 @@ func (m model) pendingChanges() []pendingChange {
 			sensitive: field.Sensitive,
 		})
 	}
-	return changes
+	m.cachedPendingChanges = changes
+	m.pendingChangesValid = true
+	return m.cachedPendingChanges
 }
 
-func (m model) pendingChangeLines(maxVisible int) []string {
+func (m *model) pendingChangeLines(maxVisible int) []string {
 	changes := m.pendingChanges()
 	if len(changes) == 0 {
 		return nil

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -201,11 +201,9 @@ func (m model) commitEdit() (tea.Model, tea.Cmd) {
 	if changed {
 		if m.fields[m.cursor].Sensitive {
 			m.fields[m.cursor].Value = val
-			m.fields[m.cursor].Source = config.SourceDotEnvLocal
 		} else {
 			config.ApplyField(&m.cfg, key, val)
 			m.fields[m.cursor].Value = val
-			m.fields[m.cursor].Source = config.SourceConfigFile
 		}
 	}
 
@@ -268,6 +266,8 @@ func (m *model) save() {
 		}
 	}
 
+	m.applyPersistedSources()
+
 	m.baseline = snapshotValues(m.fields)
 	m.recomputeDirty()
 	m.errMsg = ""
@@ -304,6 +304,24 @@ type pendingChange struct {
 
 func (m *model) recomputeDirty() {
 	m.dirty = len(m.pendingChanges()) > 0
+}
+
+func (m *model) applyPersistedSources() {
+	for i := range m.fields {
+		before := m.baseline[m.fields[i].Key]
+		if m.fields[i].Value == before {
+			continue
+		}
+		if m.fields[i].Sensitive {
+			if strings.TrimSpace(m.fields[i].Value) == "" {
+				m.fields[i].Source = config.SourceDefault
+			} else {
+				m.fields[i].Source = config.SourceDotEnvLocal
+			}
+			continue
+		}
+		m.fields[i].Source = config.SourceConfigFile
+	}
 }
 
 func (m model) pendingChanges() []pendingChange {
@@ -503,7 +521,11 @@ func (m model) stateLines() []string {
 		if m.statusMsg != "" {
 			lines = append(lines, ui.Green.Render(m.statusMsg))
 		}
-		lines = append(lines, m.pendingChangeLines(4)...)
+		pending := m.pendingChangeLines(4)
+		lines = append(lines, pending...)
+		if len(pending) > 0 {
+			lines = append(lines, settingsSubtleStyle.Render("Source labels update after save."))
+		}
 	}
 
 	return lines

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -249,15 +249,22 @@ func (m *model) save() {
 
 	// Save secrets to .env.local.
 	for _, f := range m.fields {
-		if f.Sensitive && f.Value != "" {
-			envKey := config.EnvVarForField(f.Key)
-			if envKey == "" {
-				envKey = f.Key
-			}
-			if err := config.SaveSecret(envKey, f.Value); err != nil {
-				m.errMsg = fmt.Sprintf("Save secret %s failed: %v", f.Key, err)
-				return
-			}
+		if !f.Sensitive {
+			continue
+		}
+		envKey := config.EnvVarForField(f.Key)
+		if envKey == "" {
+			envKey = f.Key
+		}
+		var err error
+		if strings.TrimSpace(f.Value) == "" {
+			err = config.DeleteSecret(envKey)
+		} else {
+			err = config.SaveSecret(envKey, f.Value)
+		}
+		if err != nil {
+			m.errMsg = fmt.Sprintf("Save secret %s failed: %v", f.Key, err)
+			return
 		}
 	}
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -25,6 +25,7 @@ const (
 type model struct {
 	cfg       config.Config
 	fields    []config.FieldInfo
+	baseline  map[string]string
 	cursor    int
 	state     viewState
 	input     textinput.Model
@@ -44,12 +45,21 @@ func initialModel(cfg config.Config) model {
 	fields := config.EffectiveFields(cfg)
 
 	return model{
-		cfg:    cfg,
-		fields: fields,
-		cursor: 0,
-		state:  stateBrowsing,
-		input:  ti,
+		cfg:      cfg,
+		fields:   fields,
+		baseline: snapshotValues(fields),
+		cursor:   0,
+		state:    stateBrowsing,
+		input:    ti,
 	}
+}
+
+func snapshotValues(fields []config.FieldInfo) map[string]string {
+	out := make(map[string]string, len(fields))
+	for _, field := range fields {
+		out[field.Key] = field.Value
+	}
+	return out
 }
 
 // Run launches the settings TUI as its own tea.Program.
@@ -180,6 +190,7 @@ func (m model) handleEditingKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m model) commitEdit() (tea.Model, tea.Cmd) {
 	key := m.fields[m.cursor].Key
 	val := m.input.Value()
+	changed := m.fields[m.cursor].Value != val
 
 	if err := config.ValidateField(key, val); err != nil {
 		m.errMsg = err.Error()
@@ -187,19 +198,25 @@ func (m model) commitEdit() (tea.Model, tea.Cmd) {
 	}
 
 	// Apply to the in-memory config or track secret change.
-	if m.fields[m.cursor].Sensitive {
-		m.fields[m.cursor].Value = val
-		m.fields[m.cursor].Source = config.SourceDotEnvLocal
-	} else {
-		config.ApplyField(&m.cfg, key, val)
-		m.fields[m.cursor].Value = val
-		m.fields[m.cursor].Source = config.SourceConfigFile
+	if changed {
+		if m.fields[m.cursor].Sensitive {
+			m.fields[m.cursor].Value = val
+			m.fields[m.cursor].Source = config.SourceDotEnvLocal
+		} else {
+			config.ApplyField(&m.cfg, key, val)
+			m.fields[m.cursor].Value = val
+			m.fields[m.cursor].Source = config.SourceConfigFile
+		}
 	}
 
-	m.dirty = true
+	m.recomputeDirty()
 	m.state = stateBrowsing
 	m.errMsg = ""
-	m.statusMsg = fmt.Sprintf("Updated %s", key)
+	if changed {
+		m.statusMsg = fmt.Sprintf("Updated %s", key)
+	} else {
+		m.statusMsg = fmt.Sprintf("No change for %s", key)
+	}
 	m.input.Blur()
 	return m, nil
 }
@@ -218,7 +235,7 @@ func (m *model) resetField() {
 	config.ApplyField(&m.cfg, f.Key, def)
 	f.Value = def
 	f.Source = config.SourceDefault
-	m.dirty = true
+	m.recomputeDirty()
 	m.errMsg = ""
 	m.statusMsg = fmt.Sprintf("Reset %s to default", f.Key)
 }
@@ -244,7 +261,8 @@ func (m *model) save() {
 		}
 	}
 
-	m.dirty = false
+	m.baseline = snapshotValues(m.fields)
+	m.recomputeDirty()
 	m.errMsg = ""
 	m.statusMsg = "Settings saved"
 }
@@ -268,6 +286,56 @@ func (m model) handleConfirmQuitKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 	return m, nil
+}
+
+type pendingChange struct {
+	key       string
+	oldValue  string
+	newValue  string
+	sensitive bool
+}
+
+func (m *model) recomputeDirty() {
+	m.dirty = len(m.pendingChanges()) > 0
+}
+
+func (m model) pendingChanges() []pendingChange {
+	changes := make([]pendingChange, 0)
+	for _, field := range m.fields {
+		before := m.baseline[field.Key]
+		if field.Value == before {
+			continue
+		}
+		changes = append(changes, pendingChange{
+			key:       field.Key,
+			oldValue:  before,
+			newValue:  field.Value,
+			sensitive: field.Sensitive,
+		})
+	}
+	return changes
+}
+
+func (m model) pendingChangeLines(maxVisible int) []string {
+	changes := m.pendingChanges()
+	if len(changes) == 0 {
+		return nil
+	}
+
+	if maxVisible <= 0 {
+		maxVisible = len(changes)
+	}
+
+	lines := make([]string, 0, maxVisible+2)
+	lines = append(lines, ui.Yellow.Render(fmt.Sprintf("Unsaved changes (%d):", len(changes))))
+	for i, ch := range changes {
+		if i >= maxVisible {
+			lines = append(lines, settingsSubtleStyle.Render(fmt.Sprintf("  ... +%d more", len(changes)-maxVisible)))
+			break
+		}
+		lines = append(lines, ui.Green.Render(fmt.Sprintf("  - %s: %s -> %s", ch.key, changeValueDisplay(ch.oldValue, ch.sensitive), changeValueDisplay(ch.newValue, ch.sensitive))))
+	}
+	return lines
 }
 
 var (
@@ -420,6 +488,7 @@ func (m model) stateLines() []string {
 		if m.errMsg != "" {
 			lines = append(lines, ui.Red.Render(m.errMsg))
 		}
+		lines = append(lines, m.pendingChangeLines(3)...)
 	default:
 		if m.errMsg != "" {
 			lines = append(lines, ui.Red.Render(m.errMsg))
@@ -427,9 +496,7 @@ func (m model) stateLines() []string {
 		if m.statusMsg != "" {
 			lines = append(lines, ui.Green.Render(m.statusMsg))
 		}
-		if m.dirty {
-			lines = append(lines, ui.Yellow.Render("Unsaved changes"))
-		}
+		lines = append(lines, m.pendingChangeLines(4)...)
 	}
 
 	return lines
@@ -464,16 +531,20 @@ func (m model) controlsHint() string {
 }
 
 func fieldDisplayValue(f config.FieldInfo) string {
-	if f.Sensitive {
-		if strings.TrimSpace(f.Value) == "" {
+	return changeValueDisplay(f.Value, f.Sensitive)
+}
+
+func changeValueDisplay(value string, sensitive bool) string {
+	if sensitive {
+		if strings.TrimSpace(value) == "" {
 			return "(not set)"
 		}
 		return "****"
 	}
-	if strings.TrimSpace(f.Value) == "" {
+	if strings.TrimSpace(value) == "" {
 		return "(not set)"
 	}
-	return f.Value
+	return value
 }
 
 func (m model) visibleRows() int {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -250,6 +250,7 @@ func (m *model) save() {
 	}
 
 	// Save secrets to .env.local.
+	secretFailures := make([]string, 0)
 	for _, f := range m.fields {
 		if !f.Sensitive {
 			continue
@@ -265,9 +266,13 @@ func (m *model) save() {
 			err = config.SaveSecret(envKey, f.Value)
 		}
 		if err != nil {
-			m.errMsg = fmt.Sprintf("Save secret %s failed: %v", f.Key, err)
-			return
+			secretFailures = append(secretFailures, fmt.Sprintf("%s: %v", f.Key, err))
 		}
+	}
+	if len(secretFailures) > 0 {
+		m.errMsg = fmt.Sprintf("Save secrets failed for %s. Some changes may have been saved.", strings.Join(secretFailures, "; "))
+		m.statusMsg = ""
+		return
 	}
 
 	m.applyPersistedSources()

--- a/internal/settings/settings_ui_test.go
+++ b/internal/settings/settings_ui_test.go
@@ -69,3 +69,54 @@ func TestSettingsControlsReflectEditingState(t *testing.T) {
 		t.Fatalf("expected editing controls hint")
 	}
 }
+
+func TestSettingsViewShowsUnsavedChangeList(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	m := initialModel(config.Default())
+	m.width = 120
+	m.height = 30
+
+	modelIndex := findFieldIndex(t, m.fields, "model")
+	m.fields[modelIndex].Value = "mistral-large-latest"
+	m.recomputeDirty()
+
+	view := m.View()
+	if !strings.Contains(view, "Unsaved changes (1):") {
+		t.Fatalf("expected unsaved changes header, got %q", view)
+	}
+	if !strings.Contains(view, "- model: mistral-small-latest -> mistral-large-latest") {
+		t.Fatalf("expected unsaved model diff, got %q", view)
+	}
+}
+
+func TestSettingsViewMasksSensitiveUnsavedValues(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	m := initialModel(config.Default())
+	m.width = 120
+	m.height = 30
+
+	secretIndex := findFieldIndex(t, m.fields, "DIR2MCP_AUTH_TOKEN")
+	m.fields[secretIndex].Value = "very-secret-token"
+	m.recomputeDirty()
+
+	view := m.View()
+	if !strings.Contains(view, "- DIR2MCP_AUTH_TOKEN: (not set) -> ****") {
+		t.Fatalf("expected masked unsaved secret diff, got %q", view)
+	}
+	if strings.Contains(view, "very-secret-token") {
+		t.Fatalf("expected secret value to stay masked")
+	}
+}
+
+func findFieldIndex(t *testing.T, fields []config.FieldInfo, key string) int {
+	t.Helper()
+	for i, f := range fields {
+		if f.Key == key {
+			return i
+		}
+	}
+	t.Fatalf("missing field %q", key)
+	return -1
+}

--- a/internal/settings/settings_ui_test.go
+++ b/internal/settings/settings_ui_test.go
@@ -164,6 +164,56 @@ func TestSaveDeletesClearedSensitiveValues(t *testing.T) {
 	}
 }
 
+func TestSaveAggregatesSecretFailures(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "")
+	t.Setenv("ELEVENLABS_API_KEY", "")
+
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir temp: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	t.Setenv("HOME", home)
+
+	if err := os.Mkdir(".env.local", 0o755); err != nil {
+		t.Fatalf("mkdir .env.local directory: %v", err)
+	}
+
+	m := initialModel(config.Default())
+	tokenIndex := findFieldIndex(t, m.fields, "DIR2MCP_AUTH_TOKEN")
+	m.fields[tokenIndex].Value = "new-token"
+	m.recomputeDirty()
+
+	m.save()
+	if m.errMsg == "" {
+		t.Fatalf("expected aggregated secret save error")
+	}
+	if !strings.Contains(m.errMsg, "DIR2MCP_AUTH_TOKEN:") {
+		t.Fatalf("expected token key in error, got %q", m.errMsg)
+	}
+	if !strings.Contains(m.errMsg, "ELEVENLABS_API_KEY:") {
+		t.Fatalf("expected api key in error, got %q", m.errMsg)
+	}
+	if !strings.Contains(m.errMsg, "Some changes may have been saved.") {
+		t.Fatalf("expected partial-save warning, got %q", m.errMsg)
+	}
+	if !m.dirty {
+		t.Fatalf("expected dirty to remain true after failed save")
+	}
+}
+
 func findFieldIndex(t *testing.T, fields []config.FieldInfo, key string) int {
 	t.Helper()
 	for i, f := range fields {

--- a/internal/settings/settings_ui_test.go
+++ b/internal/settings/settings_ui_test.go
@@ -1,6 +1,8 @@
 package settings
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -107,6 +109,58 @@ func TestSettingsViewMasksSensitiveUnsavedValues(t *testing.T) {
 	}
 	if strings.Contains(view, "very-secret-token") {
 		t.Fatalf("expected secret value to stay masked")
+	}
+}
+
+func TestSaveDeletesClearedSensitiveValues(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir temp: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	t.Setenv("HOME", home)
+
+	if err := config.SaveSecret("DIR2MCP_AUTH_TOKEN", "seed-token"); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	m := initialModel(config.Default())
+	secretIndex := findFieldIndex(t, m.fields, "DIR2MCP_AUTH_TOKEN")
+	m.fields[secretIndex].Value = ""
+	m.recomputeDirty()
+	if !m.dirty {
+		t.Fatalf("expected dirty model before save")
+	}
+
+	m.save()
+	if m.errMsg != "" {
+		t.Fatalf("unexpected save error: %s", m.errMsg)
+	}
+	if m.dirty {
+		t.Fatalf("expected dirty to clear after save")
+	}
+	if _, ok := os.LookupEnv("DIR2MCP_AUTH_TOKEN"); ok {
+		t.Fatalf("expected process env token to be unset")
+	}
+	b, err := os.ReadFile(".env.local")
+	if err != nil {
+		t.Fatalf("read .env.local: %v", err)
+	}
+	if strings.Contains(string(b), "DIR2MCP_AUTH_TOKEN=") {
+		t.Fatalf("expected .env.local token to be removed, got %q", string(b))
 	}
 }
 

--- a/tests/settings_test.go
+++ b/tests/settings_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alibilge/dirstral-cli/internal/config"
@@ -117,6 +118,29 @@ func TestSaveSecretWritesDotEnvLocalAndEnvironment(t *testing.T) {
 	}
 	if got := os.Getenv("ELEVENLABS_API_KEY"); got != "test-secret" {
 		t.Fatalf("env not updated: got %q", got)
+	}
+}
+
+func TestDeleteSecretRemovesDotEnvLocalAndEnvironment(t *testing.T) {
+	chdirTemp(t)
+	unsetEnv(t, "ELEVENLABS_API_KEY")
+
+	if err := config.SaveSecret("ELEVENLABS_API_KEY", "test-secret"); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+	if err := config.DeleteSecret("ELEVENLABS_API_KEY"); err != nil {
+		t.Fatalf("delete secret: %v", err)
+	}
+
+	b, err := os.ReadFile(".env.local")
+	if err != nil {
+		t.Fatalf("read .env.local: %v", err)
+	}
+	if strings.Contains(string(b), "ELEVENLABS_API_KEY=") {
+		t.Fatalf("expected .env.local to remove ELEVENLABS_API_KEY, got %q", string(b))
+	}
+	if _, ok := os.LookupEnv("ELEVENLABS_API_KEY"); ok {
+		t.Fatalf("expected ELEVENLABS_API_KEY to be unset")
 	}
 }
 


### PR DESCRIPTION
## Summary
- track baseline values in the Settings TUI and compute real unsaved diffs instead of a generic dirty flag message
- render per-field unsaved changes in-screen as `old -> new`, including compact truncation for long lists
- mask secret diffs in the unsaved list (`(not set)` / `****`) so sensitive values are never shown

## Verification
- go test ./internal/settings
- go test ./tests
- go test ./...
- go vet ./...

No open issue is directly tracked for this UX follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show a list of pending unsaved changes in settings UI with baseline tracking and masked display for sensitive values.
  * Add secret-deletion support from local env and process.
  * New CLI command entry point.

* **Bug Fixes**
  * Improved change detection to only apply edits when values differ; status messages clarify Updated vs No change.
  * Save now removes cleared secrets and updates unsaved-state correctly.

* **Tests**
  * Added UI tests for unsaved-change listing and masking, plus tests for secret-deletion.

* **Chores**
  * Updated ignore rules for build artifacts; README build/install notes added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->