### PR TITLE
chore: restore internal protocol/x402, drop dirstral-spec dep

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,4 +55,4 @@ jobs:
           go-version: "1.24"
 
       - name: Smoke Tests
-        run: go test -v -count=1 ./tests -run '^TestSmoke'
+        run: go test -v -count=1 ./tests/dirstral -run '^TestSmoke'

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
-	github.com/dirstral/dirstral-spec v0.0.0-20260312214207-1b0bdbed8634 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEX
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/dirstral/dirstral-spec v0.0.0-20260312214207-1b0bdbed8634 h1:KjEdIABhaaaM5m1xxcwPsZRFrdj1g9db7GeV6r26uaQ=
-github.com/dirstral/dirstral-spec v0.0.0-20260312214207-1b0bdbed8634/go.mod h1:aytF/mdHqxiqJ3lHR5Li7JBtpMh8Eu4Z4kLgK7qPNUk=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 	tea "github.com/charmbracelet/bubbletea"
 )
 

--- a/internal/chat/chat_ui.go
+++ b/internal/chat/chat_ui.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 	"github.com/dirstral/dirstral-cli/internal/ui"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"

--- a/internal/chat/loop.go
+++ b/internal/chat/loop.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 	"github.com/dirstral/dirstral-cli/internal/ui"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 	"github.com/BurntSushi/toml"
 	"github.com/joho/godotenv"
 )

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/dirstral/dirstral-cli/internal/buildinfo"
 	"github.com/dirstral/dirstral-cli/internal/config"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 	"github.com/dirstral/dirstral-cli/internal/ui"
 )
 

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dirstral/dirstral-spec/protocol"
-	"github.com/dirstral/dirstral-spec/x402"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
+	"github.com/dirstral/dirstral-cli/internal/x402"
 )
 
 const protocolVersion = protocol.DefaultProtocolVersion

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dirstral/dirstral-spec/protocol"
-	"github.com/dirstral/dirstral-spec/x402"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
+	"github.com/dirstral/dirstral-cli/internal/x402"
 )
 
 const (

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -1,0 +1,44 @@
+package protocol
+
+const (
+	ToolNameSearch           = "dir2mcp.search"
+	ToolNameAsk              = "dir2mcp.ask"
+	ToolNameAskAudio         = "dir2mcp.ask_audio"
+	ToolNameOpenFile         = "dir2mcp.open_file"
+	ToolNameListFiles        = "dir2mcp.list_files"
+	ToolNameStats            = "dir2mcp.stats"
+	ToolNameTranscribe       = "dir2mcp.transcribe"
+	ToolNameAnnotate         = "dir2mcp.annotate"
+	ToolNameTranscribeAndAsk = "dir2mcp.transcribe_and_ask"
+)
+
+const (
+	ErrorCodeUnauthorized      = "UNAUTHORIZED"
+	ErrorCodeSessionNotFound   = "SESSION_NOT_FOUND"
+	ErrorCodeIndexNotReady     = "INDEX_NOT_READY"
+	ErrorCodeFileNotFound      = "FILE_NOT_FOUND"
+	ErrorCodePermissionDenied  = "PERMISSION_DENIED"
+	ErrorCodeRateLimitExceeded = "RATE_LIMIT_EXCEEDED"
+	// ErrorCodeRateLimited is kept as a compatibility alias.
+	ErrorCodeRateLimited = ErrorCodeRateLimitExceeded
+)
+
+const (
+	DefaultListenAddr = "127.0.0.1:8087"
+	DefaultMCPPath    = "/mcp"
+	DefaultTransport  = "streamable-http"
+	DefaultModel      = "mistral-small-latest"
+
+	MCPSessionHeader         = "MCP-Session-Id"
+	MCPSessionExpiredHeader  = "X-MCP-Session-Expired"
+	MCPProtocolVersionHeader = "MCP-Protocol-Version"
+
+	DefaultProtocolVersion = "2025-11-25"
+)
+
+const (
+	RPCMethodInitialize               = "initialize"
+	RPCMethodNotificationsInitialized = "notifications/initialized"
+	RPCMethodToolsList                = "tools/list"
+	RPCMethodToolsCall                = "tools/call"
+)

--- a/internal/voice/voice.go
+++ b/internal/voice/voice.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 	tea "github.com/charmbracelet/bubbletea"
 )
 

--- a/internal/voice/voice_ui.go
+++ b/internal/voice/voice_ui.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dirstral/dirstral-cli/internal/chat"
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 	"github.com/dirstral/dirstral-cli/internal/ui"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"

--- a/internal/x402/types.go
+++ b/internal/x402/types.go
@@ -1,0 +1,265 @@
+package x402
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+const (
+	HeaderPaymentRequired  = "PAYMENT-REQUIRED"
+	HeaderPaymentSignature = "PAYMENT-SIGNATURE"
+	HeaderPaymentResponse  = "PAYMENT-RESPONSE"
+
+	ModeOff      = "off"
+	ModeOn       = "on"
+	ModeRequired = "required"
+
+	CodePaymentRequired               = "PAYMENT_REQUIRED"
+	CodePaymentInvalid                = "PAYMENT_INVALID"
+	CodePaymentFacilitatorUnavailable = "PAYMENT_FACILITATOR_UNAVAILABLE"
+	CodePaymentSettlementFailed       = "PAYMENT_SETTLEMENT_FAILED"
+	CodePaymentSettlementUnavailable  = "PAYMENT_SETTLEMENT_UNAVAILABLE"
+	CodePaymentConfigInvalid          = "PAYMENT_CONFIG_INVALID"
+
+	// X402Version is the current protocol version encoded in the
+	// PAYMENT-REQUIRED header payload.  It's a small integer that
+	// allows clients/servers to evolve the format in a backwards-
+	// compatible way, and having it as a constant makes updates
+	// straightforward.
+	X402Version = 2
+)
+
+type Requirement struct {
+	Scheme            string
+	Network           string
+	Amount            string
+	MaxAmountRequired string
+	Asset             string
+	PayTo             string
+	Resource          string
+}
+
+// X402Payload represents the JSON object returned in the PAYMENT-REQUIRED header.
+// It mirrors the previous map structure but provides compile-time safety.
+//
+// Consumers depend on the field names to match the existing keys, so the tags
+// are chosen accordingly.
+type X402Payload struct {
+	X402Version int           `json:"x402Version"`
+	Accept      []AcceptEntry `json:"accepts"`
+}
+
+// AcceptEntry describes a single acceptable payment requirement.
+// The json tags match the keys previously used in the map literal.
+type AcceptEntry struct {
+	Scheme            string `json:"scheme"`
+	Network           string `json:"network"`
+	Amount            string `json:"amount"`
+	MaxAmountRequired string `json:"maxAmountRequired,omitempty"`
+	Asset             string `json:"asset"`
+	PayTo             string `json:"payTo"`
+	Resource          string `json:"resource"`
+}
+
+const allowedSchemesText = "exact, upto"
+
+func (r Requirement) Validate() error {
+	// normalize and check scheme value
+	scheme := strings.ToLower(strings.TrimSpace(r.Scheme))
+	if scheme == "" {
+		return fmt.Errorf("x402 scheme is required")
+	}
+	switch scheme {
+	case "exact", "upto":
+	default:
+		return fmt.Errorf("x402 scheme must be one of: %s", allowedSchemesText)
+	}
+	if strings.TrimSpace(r.Network) == "" {
+		return fmt.Errorf("x402 network is required")
+	}
+	if !IsCAIP2Network(r.Network) {
+		return fmt.Errorf("x402 network must be CAIP-2")
+	}
+	// amount must be a non-empty positive integer.
+	amt := strings.TrimSpace(r.Amount)
+	if amt == "" {
+		return fmt.Errorf("x402 amount is required")
+	}
+	value := new(big.Int)
+	if _, ok := value.SetString(amt, 10); !ok || value.Sign() <= 0 {
+		return fmt.Errorf("x402 amount must be a positive integer")
+	}
+
+	// For "upto" scheme we also require a max value which must be a
+	// positive integer and not smaller than amount.  The MaxAmountRequired
+	// field may be empty for "exact" since it is ignored.
+	if scheme == "upto" {
+		max := strings.TrimSpace(r.MaxAmountRequired)
+		if max == "" {
+			return fmt.Errorf("x402 maxAmountRequired is required for upto scheme")
+		}
+		maxVal := new(big.Int)
+		if _, ok := maxVal.SetString(max, 10); !ok || maxVal.Sign() <= 0 {
+			return fmt.Errorf("x402 maxAmountRequired must be a positive integer")
+		}
+		if maxVal.Cmp(value) < 0 {
+			return fmt.Errorf("x402 maxAmountRequired must be >= amount")
+		}
+	}
+	if strings.TrimSpace(r.Asset) == "" {
+		return fmt.Errorf("x402 asset is required")
+	}
+	if strings.TrimSpace(r.PayTo) == "" {
+		return fmt.Errorf("x402 pay_to is required")
+	}
+	if strings.TrimSpace(r.Resource) == "" {
+		return fmt.Errorf("x402 resource is required")
+	}
+	return nil
+}
+
+// BuildPaymentRequiredHeaderValue returns a machine-readable challenge payload
+// suitable for the PAYMENT-REQUIRED header.
+func BuildPaymentRequiredHeaderValue(req Requirement) (string, error) {
+	if err := req.Validate(); err != nil {
+		return "", err
+	}
+
+	// assemble a typed payload rather than a loose map; this aids
+	// compile-time checking and prevents inadvertent typos.
+	p := X402Payload{
+		X402Version: X402Version,
+		Accept: []AcceptEntry{
+			{
+				Scheme:            strings.ToLower(strings.TrimSpace(req.Scheme)),
+				Network:           strings.TrimSpace(req.Network),
+				Amount:            strings.TrimSpace(req.Amount),
+				MaxAmountRequired: strings.TrimSpace(req.MaxAmountRequired),
+				Asset:             strings.TrimSpace(req.Asset),
+				PayTo:             strings.TrimSpace(req.PayTo),
+				Resource:          strings.TrimSpace(req.Resource),
+			},
+		},
+	}
+
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func NormalizeMode(mode string) string {
+	// Normalize user-supplied mode strings to one of the canonical
+	// constants.  This helper is used at runtime during configuration
+	// to decide whether payment gating is enabled, so it's important
+	// that the return value is always a valid mode.  Previously the
+	// function would return unknown values lowercased which meant
+	// callers such as IsModeValid could disagree with each other.
+	//
+	// After trimming and lowercasing we map anything that isn't
+	// explicitly recognised back to ModeOff.  Callers that need to
+	// validate the original input should use IsModeValid instead.
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	switch mode {
+	case "", ModeOff:
+		return ModeOff
+	case ModeOn:
+		return ModeOn
+	case ModeRequired:
+		return ModeRequired
+	default:
+		// unrecognised values fall back to off rather than leaking
+		// arbitrary strings; this keeps the output in the set of
+		// known modes and avoids surprising callers.
+		return ModeOff
+	}
+}
+
+func IsModeValid(mode string) bool {
+	// Validate the raw input rather than normalising it.  With the
+	// new behaviour of NormalizeMode the previous implementation would
+	// always return true, which made the helper useless.  Keeping this
+	// logic separate lets callers detect and reject bad configuration
+	// while still using NormalizeMode for runtime decisions.
+	m := strings.ToLower(strings.TrimSpace(mode))
+	switch m {
+	case ModeOff, ModeOn, ModeRequired:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsModeEnabled(mode string) bool {
+	switch NormalizeMode(mode) {
+	case ModeOn, ModeRequired:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsCAIP2Network validates a conservative CAIP-2 identifier shape:
+// <namespace>:<reference>
+func IsCAIP2Network(network string) bool {
+	network = strings.TrimSpace(network)
+	parts := strings.Split(network, ":")
+	if len(parts) != 2 {
+		return false
+	}
+
+	ns := parts[0]
+	ref := parts[1]
+	if len(ns) == 0 || len(ns) > 32 || len(ref) == 0 || len(ref) > 128 {
+		return false
+	}
+
+	for _, r := range ns {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	for _, r := range ref {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+type FacilitatorError struct {
+	Operation  string
+	StatusCode int
+	Retryable  bool
+	Code       string
+	Message    string
+	Body       string
+	Cause      error
+}
+
+func (e *FacilitatorError) Error() string {
+	if e == nil {
+		return "<nil FacilitatorError>"
+	}
+	if e.Code == "" && e.Message == "" {
+		return "facilitator request failed"
+	}
+	if e.Code == "" {
+		return e.Message
+	}
+	if e.Message == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.Message
+}
+
+func (e *FacilitatorError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}

--- a/internal/x402/types.go
+++ b/internal/x402/types.go
@@ -112,7 +112,7 @@ func (r Requirement) Validate() error {
 		return fmt.Errorf("x402 asset is required")
 	}
 	if strings.TrimSpace(r.PayTo) == "" {
-		return fmt.Errorf("x402 pay_to is required")
+		return fmt.Errorf("x402 payTo is required")
 	}
 	if strings.TrimSpace(r.Resource) == "" {
 		return fmt.Errorf("x402 resource is required")
@@ -202,8 +202,8 @@ func IsModeEnabled(mode string) bool {
 	}
 }
 
-// IsCAIP2Network validates a conservative CAIP-2 identifier shape:
-// <namespace>:<reference>
+// IsCAIP2Network validates a CAIP-2 identifier of the form
+// <namespace>:<reference>, matching ^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}$.
 func IsCAIP2Network(network string) bool {
 	network = strings.TrimSpace(network)
 	parts := strings.Split(network, ":")
@@ -213,12 +213,12 @@ func IsCAIP2Network(network string) bool {
 
 	ns := parts[0]
 	ref := parts[1]
-	if len(ns) == 0 || len(ns) > 32 || len(ref) == 0 || len(ref) > 128 {
+	if len(ns) < 3 || len(ns) > 8 || len(ref) == 0 || len(ref) > 32 {
 		return false
 	}
 
 	for _, r := range ns {
-		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
 			return false
 		}
 	}

--- a/internal/x402/types.go
+++ b/internal/x402/types.go
@@ -178,12 +178,12 @@ func NormalizeMode(mode string) string {
 	}
 }
 
+// IsModeValid reports whether mode is one of the recognised constants
+// (ModeOff, ModeOn, ModeRequired). Unlike NormalizeMode, it does not default
+// unknown or empty input — the empty string returns false. Use NormalizeMode
+// when defaulting behaviour is wanted; use IsModeValid when validating
+// user-supplied configuration.
 func IsModeValid(mode string) bool {
-	// Validate the raw input rather than normalising it.  With the
-	// new behaviour of NormalizeMode the previous implementation would
-	// always return true, which made the helper useless.  Keeping this
-	// logic separate lets callers detect and reject bad configuration
-	// while still using NormalizeMode for runtime decisions.
 	m := strings.ToLower(strings.TrimSpace(mode))
 	switch m {
 	case ModeOff, ModeOn, ModeRequired:
@@ -242,9 +242,6 @@ type FacilitatorError struct {
 }
 
 func (e *FacilitatorError) Error() string {
-	if e == nil {
-		return "<nil FacilitatorError>"
-	}
 	if e.Code == "" && e.Message == "" {
 		return "facilitator request failed"
 	}
@@ -258,8 +255,5 @@ func (e *FacilitatorError) Error() string {
 }
 
 func (e *FacilitatorError) Unwrap() error {
-	if e == nil {
-		return nil
-	}
 	return e.Cause
 }

--- a/tests/dirstral/chat_json_test.go
+++ b/tests/dirstral/chat_json_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/dirstral/dirstral-cli/internal/chat"
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 )
 
 func decodeEvents(t *testing.T, data []byte) []map[string]any {

--- a/tests/dirstral/chat_planner_test.go
+++ b/tests/dirstral/chat_planner_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/dirstral/dirstral-cli/internal/chat"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 )
 
 func TestPlannerModelProfileAffectsStrategyAndSynthesis(t *testing.T) {

--- a/tests/dirstral/mcp_errors_test.go
+++ b/tests/dirstral/mcp_errors_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
-	"github.com/dirstral/dirstral-spec/x402"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
+	"github.com/dirstral/dirstral-cli/internal/x402"
 )
 
 func TestCanonicalCodeFromError(t *testing.T) {

--- a/tests/dirstral/mcp_session_recovery_test.go
+++ b/tests/dirstral/mcp_session_recovery_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 )
 
 func reportHandlerErr(ch chan error, format string, args ...any) {

--- a/tests/dirstral/mcp_stdio_test.go
+++ b/tests/dirstral/mcp_stdio_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 )
 
 func TestMCPClientStdioInitializeAndCall(t *testing.T) {

--- a/tests/dirstral/mode_flow_test.go
+++ b/tests/dirstral/mode_flow_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/dirstral/dirstral-cli/internal/config"
 	"github.com/dirstral/dirstral-cli/internal/host"
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 )
 
 func TestModeFlowSmokeServerToChatToVoiceHandoff(t *testing.T) {

--- a/tests/dirstral/root_test.go
+++ b/tests/dirstral/root_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dirstral/dirstral-cli/internal/app"
 	"github.com/dirstral/dirstral-cli/internal/config"
 	"github.com/dirstral/dirstral-cli/internal/host"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 )
 
 func TestBuildVoiceOptionsPrefersFlags(t *testing.T) {

--- a/tests/dirstral/server_status_test.go
+++ b/tests/dirstral/server_status_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/dirstral/dirstral-cli/internal/host"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 )
 
 func TestComputeMCPURLDeterministic(t *testing.T) {

--- a/tests/dirstral/smoke_chat_test.go
+++ b/tests/dirstral/smoke_chat_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/dirstral/dirstral-cli/internal/chat"
 	"github.com/dirstral/dirstral-cli/internal/mcp"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 )
 
 func TestSmokeChatJSONOverStdio(t *testing.T) {

--- a/tests/dirstral/smoke_server_test.go
+++ b/tests/dirstral/smoke_server_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dirstral-cli/internal/host"
-	"github.com/dirstral/dirstral-spec/protocol"
+	"github.com/dirstral/dirstral-cli/internal/protocol"
 )
 
 func TestSmokeServerLifecycleWithFakeDir2MCP(t *testing.T) {


### PR DESCRIPTION
dirstral-spec is being reverted to docs-only. Move the Go packages back into internal.

## Changes
- Restore `internal/protocol/constants.go`
- Restore `internal/x402/types.go`
- Rewrite imports from `github.com/dirstral/dirstral-spec/...` → `github.com/dirstral/dirstral-cli/internal/...`
- Remove `github.com/dirstral/dirstral-spec` from go.mod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added X402 payment protocol support: structured payment validation and PAYMENT-REQUIRED header construction.
* **Chores**
  * Internalized protocol definitions and centralized protocol constants for tools, errors, defaults, headers, and RPC methods.
  * Removed an external protocol dependency and updated code to use the internal protocol implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->