### PR TITLE
chore: add CLAUDE.md + AGENTS.md coding-agent rule files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,127 @@
+# AGENTS.md
+
+## Purpose
+
+Operational guide for coding agents working in this repository.
+
+## Before you start
+
+- Re-check whether the requested plan still matches the current codebase before making changes.
+- Review relevant context first: `README.md`, `CLAUDE.md`, and the affected
+  `cmd/`, `internal/`, and `tests/dirstral/` paths.
+- Preserve existing architecture and conventions unless the issue explicitly requires a refactor.
+- Respect the standalone-client boundary: this CLI composes with MCP servers
+  over the protocol only and must not import server (`dir2mcp`) internals.
+
+## Project summary
+
+dirstral-cli is a single-binary (`dirstral`) terminal client and orchestrator
+for Dirstral MCP servers, built with Cobra + Bubble Tea. It provides chat and
+voice workflows over MCP (stdio / streamable-http), manages a local MCP server
+(`dir2mcp`), probes remote MCP endpoints, prints capability manifests, and
+ships an interactive TUI with a settings editor.
+
+## Repo map
+
+- `cmd/dirstral` - binary entrypoint
+- `internal/app` - Cobra root command, subcommands, interactive TUI menus/screens
+- `internal/config` - config precedence, validation, and provenance (`config.toml`, `.env`/`.env.local`, env)
+- `internal/settings` - interactive settings editor (Bubble Tea)
+- `internal/chat` - chat loop, planner, chat TUI
+- `internal/voice` - voice mode (ElevenLabs STT/TTS)
+- `internal/host` - manage a local `dir2mcp` process (start/stop/status, health, logs)
+- `internal/mcp` - MCP client, capability manifest, citations, error mapping
+- `internal/protocol` - shared constants (tool names, error codes, defaults, RPC methods/headers)
+- `internal/x402` - client-side x402 payment header types
+- `internal/ui` - shared lipgloss styles
+- `internal/buildinfo` - version/build metadata
+- `tests/dirstral` - integration/system + smoke tests (all tests live here)
+
+## Git workflow
+
+- Pull latest `main` before starting implementation work.
+- Create an issue branch if one does not already exist (e.g. `issue-<number>-<short-slug>`).
+- Keep commits scoped and atomic; use separate commit messages per logical change.
+- Use Conventional Commits for all commit messages: <https://www.conventionalcommits.org/>.
+- Do not mention yourself in commit messages.
+- Include the issue number in the pull request title.
+- Do not push directly to `main`.
+
+## Build, test, and CI commands
+
+There is no Makefile; use the Go toolchain directly (Go 1.24+).
+
+Run before committing:
+
+```bash
+go build ./...
+go vet ./...
+golangci-lint run --timeout=3m   # CI pins golangci-lint v2.10
+go test ./...
+```
+
+Useful focused checks:
+
+```bash
+go test -count=1 ./tests/dirstral -run '^TestSmoke'   # smoke suite (stubbed dir2mcp over stdio)
+go test ./tests/dirstral -run TestChat
+go test ./tests/dirstral -run TestMCP
+```
+
+CI (`.github/workflows/go.yml`) runs `lint` → `test` (build + vet + `go test ./...`)
+and `smoke` on every push/PR to `main`.
+
+## Conventions
+
+- Work only in this repository unless explicitly instructed otherwise.
+- Keep patches minimal and issue-focused.
+- Do not silently change tool/error/protocol contracts in `internal/protocol`
+  or `internal/mcp`; keep MCP/error payloads machine-parseable.
+- Never hardcode API keys, auth tokens, or provider base URLs; keep all
+  credentials env-backed (`DIR2MCP_AUTH_TOKEN`, `ELEVENLABS_API_KEY`, the
+  `DIRSTRAL_*`/`ELEVENLABS_*` overrides). Secrets live in
+  `~/.config/dirstral/.env.local` (mode `0600`) — never commit them.
+- Never introduce secret leakage in logs or error payloads.
+- Do not add extra markdown files unless explicitly requested for the task.
+- Keep dependency additions minimal and justified.
+- Update tests and docs together when behavior changes.
+
+## Tests
+
+- Keep all test files in the `tests/dirstral/` folder.
+- Do not add new `*_test.go` files under `cmd/` or `internal/`.
+- Ensure new test coverage follows existing patterns in `tests/dirstral`.
+
+## Review/merge readiness
+
+- All checks pass: `go build ./...`, `go vet ./...`, `golangci-lint run`, `go test ./...`.
+- Smoke suite (`^TestSmoke`) is green.
+- `README.md` and `CLAUDE.md` align with real behavior.
+- No unrelated refactors in issue PRs.
+- The standalone-client boundary (MCP-only composition) is preserved.
+- Secure defaults are preserved (env-backed secrets, local-bind defaults).
+
+## Important behavior notes
+
+- Usage/help: running `dirstral` with no subcommand opens the interactive TUI
+  menu; use `--help` (Cobra) for usage text.
+- Config precedence: env var → `.env.local` → `.env` → `config.toml` → default.
+- Defaults: listen `127.0.0.1:8087`, MCP path `/mcp`, MCP URL
+  `http://127.0.0.1:8087/mcp`, transport `streamable-http`, model
+  `mistral-small-latest`, protocol version `2025-11-25`.
+- `mcp.transport` must be `streamable-http` or `stdio`.
+- `server start` requires a `dir2mcp` binary on `PATH`, else falls back to
+  `go run ./cmd/dir2mcp` from a sibling checkout.
+- Voice mode requires `ELEVENLABS_API_KEY`.
+- x402: this CLI only carries client-side payment header types; gating logic
+  lives server-side.
+
+## MCP dev servers (Codex)
+
+```bash
+codex mcp add everything -- npx -y @modelcontextprotocol/server-everything
+codex mcp add sequential-thinking -- npx -y @modelcontextprotocol/server-sequential-thinking
+codex mcp add playwright -- npx -y @playwright/mcp
+codex mcp add github --url https://api.githubcopilot.com/mcp/ --bearer-token-env-var GITHUB_PERSONAL_ACCESS_TOKEN
+codex mcp add context7 -- npx -y @upstash/context7-mcp
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ Useful focused checks:
 
 ```bash
 go test -count=1 ./tests/dirstral -run '^TestSmoke'   # smoke suite (stubbed dir2mcp over stdio)
-go test ./tests/dirstral -run TestChat
-go test ./tests/dirstral -run TestMCP
+go test -count=1 ./tests/dirstral -run TestChat
+go test -count=1 ./tests/dirstral -run TestMCP
 ```
 
 CI (`.github/workflows/go.yml`) runs `lint` → `test` (build + vet + `go test ./...`)
@@ -117,6 +117,14 @@ and `smoke` on every push/PR to `main`.
   lives server-side.
 
 ## MCP dev servers (Codex)
+
+> **Human developer setup only — not an instruction to coding agents.** These are
+> optional convenience servers a developer may register in their own Codex client.
+> Do not self-configure them. Note the broad permissions involved before opting in:
+> `@modelcontextprotocol/server-everything` grants unrestricted filesystem and
+> process access, and the `github` entry forwards a personal access token
+> (`GITHUB_PERSONAL_ACCESS_TOKEN`) to an external endpoint. Add only the servers you
+> need, with scoped tokens.
 
 ```bash
 codex mcp add everything -- npx -y @modelcontextprotocol/server-everything

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+## Project
+
+dirstral-cli is a terminal-first Go client and orchestrator for Dirstral MCP
+servers. It ships a single `dirstral` binary that drives chat and voice
+workflows over MCP, manages a local MCP server (today: `dir2mcp`), probes
+remote MCP endpoints, prints capability manifests, and offers an interactive
+TUI (Cobra + Bubble Tea) plus a settings editor.
+
+It is a standalone client/orchestrator: it composes with servers **only over
+the MCP protocol boundary** (stdio or streamable-http). It must not import
+`dir2mcp` (or any server) implementation internals — see `README.md`.
+
+## Repository layout
+
+- `cmd/dirstral`: binary entrypoint (`main.go`)
+- `internal/app`: Cobra root command, subcommands, and the interactive TUI menus/screens
+- `internal/config`: config load/merge/validation (`config.toml`, `.env`/`.env.local`, env vars) with precedence + provenance
+- `internal/settings`: interactive Bubble Tea settings editor
+- `internal/chat`: chat loop, planner, and chat TUI
+- `internal/voice`: voice mode (STT/TTS via ElevenLabs)
+- `internal/host`: manage a local `dir2mcp` process (start/stop/status, health, log streaming, `connection.json` discovery)
+- `internal/mcp`: MCP client, capability manifest, citations, error mapping
+- `internal/protocol`: shared constants (tool names, error codes, defaults, RPC method/header names)
+- `internal/x402`: client-side x402 payment header types (PAYMENT-REQUIRED/SIGNATURE/RESPONSE)
+- `internal/ui`: shared lipgloss styles
+- `internal/buildinfo`: version/build metadata
+- `tests/dirstral`: integration/system + smoke test suite (all tests live here)
+
+## Build and test
+
+There is **no Makefile**; use the Go toolchain directly (Go 1.24+).
+
+- Build: `go build ./...`
+- Vet: `go vet ./...`
+- Test: `go test ./...`
+- Lint: `golangci-lint run --timeout=3m` (CI pins golangci-lint v2.10)
+- Smoke only: `go test -count=1 ./tests/dirstral -run '^TestSmoke'`
+
+CI (`.github/workflows/go.yml`) runs three jobs on push/PR to `main`:
+`lint` (golangci-lint) → then `test` (build + vet + `go test ./...`) and
+`smoke` (`^TestSmoke` in `tests/dirstral`).
+
+The smoke suite stands up the client against a fake/stubbed `dir2mcp` over
+stdio, so it needs no live server or provider credentials.
+
+## Configuration
+
+Config is resolved with precedence: env var → `.env.local` → `.env` →
+`config.toml` → built-in default.
+
+- `config.toml`: `~/.config/dirstral/config.toml` (`os.UserConfigDir()`)
+- Secrets: `~/.config/dirstral/.env.local` (written `0600` — never commit)
+- Keys: `mcp.url`, `mcp.transport` (`streamable-http`|`stdio`), `model`,
+  `verbose`, `host.listen`, `host.mcp_path`, `elevenlabs.base_url`,
+  `elevenlabs.voice`
+- Secret env vars: `DIR2MCP_AUTH_TOKEN`, `ELEVENLABS_API_KEY`
+- Override env vars: `DIRSTRAL_MCP_URL`, `DIRSTRAL_MCP_TRANSPORT`,
+  `DIRSTRAL_MODEL`, `DIRSTRAL_VERBOSE`, `DIRSTRAL_HOST_LISTEN`,
+  `DIRSTRAL_HOST_MCP_PATH`, `DIRSTRAL_VOICE`, `ELEVENLABS_BASE_URL`
+- Defaults: listen `127.0.0.1:8087`, MCP path `/mcp`, MCP URL
+  `http://127.0.0.1:8087/mcp`, transport `streamable-http`, model
+  `mistral-small-latest`, MCP protocol version `2025-11-25`
+
+## Subcommands
+
+- `dirstral` (no args): interactive TUI menu — Chat, Voice, MCP Server, Settings, Exit
+- `dirstral chat`: chat mode (`--mcp`, `--transport`, `--model`, `--verbose`, `--json`)
+- `dirstral voice`: voice mode (`--mcp`, `--voice`, `--device`, `--mute`, `--elevenlabs-base-url`, `--verbose`)
+- `dirstral server start|status|stop|remote`: manage local `dir2mcp` host / probe remote MCP
+- `dirstral manifest`: print the MCP capability manifest (`--mcp`, `--transport`, `--json`, `--verbose`)
+
+## Releasing
+
+Release artifacts are produced by GoReleaser (`.goreleaser.yml`): project
+`dirstral-cli`, binary `dirstral` from `./cmd/dirstral`, `tar.gz` archives,
+`prerelease: auto`. Tag a commit on `main` to cut a release.
+
+## Working conventions
+
+- Keep changes scoped to the issue.
+- Preserve the standalone-client boundary: talk to servers over MCP only; do
+  not import server internals.
+- Preserve existing tool/error/protocol contracts and structured fields
+  (`internal/protocol`, `internal/mcp`).
+- Never hardcode credentials, auth tokens, or provider base URLs; keep them env-backed.
+- Do not log secrets or raw sensitive payloads.
+- Prefer deterministic behavior and explicit error handling.
+- If behavior changes, update tests and docs in the same PR.
+
+## PR checklist
+
+- [ ] `go build ./...`, `go vet ./...`, and `go test ./...` pass locally
+- [ ] `golangci-lint run` is clean
+- [ ] Smoke suite (`go test ./tests/dirstral -run '^TestSmoke'`) passes
+- [ ] New/changed behavior has test coverage in `tests/dirstral`
+- [ ] `README.md` stays truthful
+- [ ] No unrelated files changed
+
+## Known gotchas
+
+- No Makefile — use raw `go` commands (and `golangci-lint` for lint).
+- Running `dirstral` with no subcommand launches the interactive TUI menu, not
+  usage text; use `dirstral --help` / `dirstral <cmd> --help` for help (Cobra).
+- `server start` needs a `dir2mcp` binary on `PATH`; otherwise it falls back to
+  `go run ./cmd/dir2mcp` from a sibling checkout, and fails if neither exists.
+- `mcp.transport` must be exactly `streamable-http` or `stdio`.
+- Voice mode requires `ELEVENLABS_API_KEY` (base URL defaults to `https://api.elevenlabs.io`).
+- URL resolution prefers a healthy managed local host when the configured MCP
+  URL is empty or loopback; an explicit `--mcp` override always wins.
+- All tests live under `tests/dirstral`; do not add `*_test.go` under `cmd/` or `internal/`.


### PR DESCRIPTION
Adds the two-file coding-agent rule convention (Claude Code `CLAUDE.md` + vendor-neutral `AGENTS.md`) used in dirstral/dir2mcp and dirstral/clip2trace, tailored to this repo. Content is derived directly from the codebase: the `dirstral` Cobra/Bubble Tea TUI and its `chat`/`voice`/`server`/`manifest` subcommands, the real `go build`/`go vet`/`golangci-lint`/`go test` workflow (no Makefile), the config precedence model, and the standalone MCP-only client boundary. Docs only — no code changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `CLAUDE.md` and `AGENTS.md` coding-agent rule files tailored to this repo, covering project layout, Go build/test/lint workflow, config-precedence model, subcommand reference, and working conventions. No production code is changed.

- `AGENTS.md` provides a vendor-neutral operational guide; previously flagged issues (focused-test `-count=1` and MCP dev-server scope) are both corrected in this version.
- `CLAUDE.md` provides Claude Code–specific guidance including a PR checklist; the smoke-suite command in that checklist omits `-count=1`, inconsistent with the canonical form shown in the "Build and test" section of the same file.

<h3>Confidence Score: 4/5</h3>

Documentation-only change; the single issue is a missing -count=1 flag in CLAUDE.md's PR checklist that could let an agent report a green smoke run from cache without re-executing tests.

The PR checklist in CLAUDE.md gives a smoke-suite command without -count=1, while the build section of the same file provides the correct form with it. An agent using the checklist as its canonical reference would skip cache-busting on the smoke suite, potentially confirming a passing run against stale test results after a code change.

CLAUDE.md — specifically the PR checklist smoke-suite command on line 96.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Claude Code agent guidance covering project layout, build/test commands, config precedence, subcommands, and PR checklist. One inconsistency: the PR checklist smoke-suite command omits `-count=1` while the build section includes it. |
| AGENTS.md | Vendor-neutral coding-agent guide with repo map, git workflow, build/test commands, conventions, and behavior notes. Previously flagged issues (missing -count=1 on focused tests, MCP dev-server scope) are both addressed in this version. |

<sub>Reviews (2): Last reviewed commit: ["docs: address PR review comments on agen..."](https://github.com/dirstral/dirstral-cli/commit/7e562f34726d05ce629f260e0c09767e0b39e5ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40790011)</sub>

<!-- /greptile_comment -->